### PR TITLE
[FEATURE] Add CSP middleware

### DIFF
--- a/lib/middleware/csp.js
+++ b/lib/middleware/csp.js
@@ -1,0 +1,71 @@
+var url = require('url');
+var querystring = require('querystring');
+
+var HEADER_CONTENT_SECURITY_POLICY = "Content-Security-Policy",
+    HEADER_CONTENT_SECURITY_POLICY_REPORT_ONLY = "Content-Security-Policy-Report-Only",
+    rPolicy = /([-_a-zA-Z0-9]+)(:report-only)?/i;
+
+function createMiddleware(sCspUrlParameterName, oConfig) {
+    return function csp(req, res, next) {
+        var allowDynamicPolicySelection = oConfig.allowDynamicPolicySelection || false,
+            allowDynamicPolicyDefinition = oConfig.allowDynamicPolicyDefinition || false,
+            defaultPolicyIsReportOnly = oConfig.defaultPolicyIsReportOnly || false,
+            sHeader,
+            sHeaderValue,
+            sCspUrlParameterValue,
+            oParsedUrl,
+            oQuery,
+            oPolicy,
+            mPolicyMatch,
+            bReportOnly = defaultPolicyIsReportOnly;
+
+        // If a policy with name 'default' is defined, it will even be send without a present URL parameter.
+        if (oConfig.definedPolicies["default"]) {
+            oPolicy = {
+                name: "default",
+                policy: oConfig.definedPolicies["default"]
+            };
+        }
+
+        // Use random protocol, host and port to establish a valid URL for parsing query parameters
+        oParsedUrl = url.parse(req.url);
+        oQuery = querystring.parse(oParsedUrl.query);
+        sCspUrlParameterValue = oQuery[sCspUrlParameterName];
+
+        if (sCspUrlParameterValue) {
+            mPolicyMatch = rPolicy.exec(sCspUrlParameterValue);
+
+            if (mPolicyMatch && mPolicyMatch[1] && oConfig.definedPolicies[mPolicyMatch[1]] && allowDynamicPolicySelection) {
+                oPolicy = {
+                    name: mPolicyMatch[1],
+                    policy: oConfig.definedPolicies[mPolicyMatch[1]]
+                };
+                bReportOnly = mPolicyMatch[2] !== undefined;
+            } else if (allowDynamicPolicyDefinition) {
+                // Custom CSP policy directives get passed as part of the CSP URL-Parameter value
+                bReportOnly = sCspUrlParameterValue.endsWith(":report-only");
+                if (bReportOnly) {
+                    sCspUrlParameterValue = sCspUrlParameterValue.substr(0, sCspUrlParameterValue.length - ":report-only".length);
+                }
+                oPolicy = {
+                    name: "dynamic-custom-policy",
+                    policy: sCspUrlParameterValue
+                };
+            }
+        }
+
+        if (oPolicy) {
+            sHeader = bReportOnly ? HEADER_CONTENT_SECURITY_POLICY_REPORT_ONLY : HEADER_CONTENT_SECURITY_POLICY;
+            sHeaderValue = oPolicy.policy;
+
+            // Send response with CSP header
+            res.removeHeader(HEADER_CONTENT_SECURITY_POLICY);
+            res.removeHeader(HEADER_CONTENT_SECURITY_POLICY_REPORT_ONLY);
+            res.setHeader(sHeader, sHeaderValue);
+        }
+
+        next();
+    };
+}
+
+module.exports = createMiddleware;

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,6 +8,7 @@ const serveResources = require("./middleware/serveResources");
 const discovery = require("./middleware/discovery");
 const versionInfo = require("./middleware/versionInfo");
 const serveThemes = require("./middleware/serveThemes");
+const csp = require("./middleware/csp");
 const ui5connect = require("connect-openui5");
 const nonReadRequests = require("./middleware/nonReadRequests");
 const ui5Fs = require("@ui5/fs");
@@ -50,6 +51,19 @@ function serve(tree, {port, changePortIfInUse = false, h2 = false, key, cert, ac
 		};
 
 		const app = express();
+
+		var oCspConfig = {
+			allowDynamicPolicySelection: true,
+			allowDynamicPolicyDefinition: true,
+			defaultPolicyIsReportOnly: true,
+			definedPolicies: {
+				"detailed-directives": "default-src 'none'; script-src 'self'; frame-src 'self'; connect-src 'self'; font-src 'self'; img-src 'self'; style-src 'self' 'unsafe-inline';",
+				"almost-default": "default-src 'self'; script-src 'self'; style-src 'unsafe-inline' *;",
+				"ui5-working": "default-src 'self'; script-src 'unsafe-eval' * ; style-src 'unsafe-inline' * ;"
+			}
+		};
+		app.use(csp("sap-ui-xx-csp-policy", oCspConfig));
+
 		app.use(compression());
 		app.use(cors());
 


### PR DESCRIPTION
Adds a Content Security Policy (CSP) middleware which can be enabled via URL parameter (sap-ui-xx-csp-policy). One can set the value to a policy string directly, or use one of the already defined policy IDs (detailed-directives, almost-default or ui5-working):

* detailed-directives": "default-src 'none'; script-src 'self'; frame-src 'self'; connect-src 'self'; font-src 'self'; img-src 'self'; style-src 'self' 'unsafe-inline';
* almost-default": "default-src 'self'; script-src 'self'; style-src 'unsafe-inline' *;
* ui5-working": "default-src 'self'; script-src 'unsafe-eval' * ; style-src 'unsafe-inline' * ;

The OpenUI5 QUnit test "src/sap.ui.core/test/sap/ui/core/qunit/csp/ContentSecurityPolicy.qunit.html" can be used for a starting point validating for CSP compliance.