### PR TITLE
[FIX] Makes CSP middleware work in an environment without express server

### DIFF
--- a/lib/middleware/csp.js
+++ b/lib/middleware/csp.js
@@ -1,3 +1,6 @@
+const url = require("url");
+const querystring = require("querystring");
+
 const HEADER_CONTENT_SECURITY_POLICY = "Content-Security-Policy";
 const HEADER_CONTENT_SECURITY_POLICY_REPORT_ONLY = "Content-Security-Policy-Report-Only";
 const rPolicy = /^([-_a-zA-Z0-9]+)(:report-only|:ro)?$/i;
@@ -25,9 +28,11 @@ function createMiddleware(sCspUrlParameterName, oConfig) {
 	} = oConfig;
 
 	return function csp(req, res, next) {
+		const oParsedURL = url.parse(req.url);
+
 		if (req.method === "POST" ) {
-			if (req.headers["content-type"] === "application/csp-report" &&
-				req.path.endsWith("/dummy.csplog") ) {
+			if (req.headers["content-type"] === "application/csp-report"
+				&& oParsedURL.pathname.endsWith("/dummy.csplog") ) {
 				// In report-only mode there must be a report-uri defined
 				// For now just ignore the violation. It will be logged in the browser anyway.
 				return;
@@ -37,7 +42,7 @@ function createMiddleware(sCspUrlParameterName, oConfig) {
 		}
 
 		// add CSP headers only to get requests for *.html pages
-		if (req.method !== "GET" || !req.path.endsWith(".html")) {
+		if (req.method !== "GET" || !oParsedURL.pathname.endsWith(".html")) {
 			next();
 			return;
 		}
@@ -48,7 +53,8 @@ function createMiddleware(sCspUrlParameterName, oConfig) {
 		const policy2 = defaultPolicy2 && definedPolicies[defaultPolicy2];
 		const reportOnly2 = defaultPolicy2IsReportOnly;
 
-		const sCspUrlParameterValue = req.query[sCspUrlParameterName];
+		const oQuery = querystring.parse(oParsedURL.query);
+		const sCspUrlParameterValue = oQuery[sCspUrlParameterName];
 		if (sCspUrlParameterValue) {
 			const mPolicyMatch = rPolicy.exec(sCspUrlParameterValue);
 

--- a/test/lib/server/middleware/csp.js
+++ b/test/lib/server/middleware/csp.js
@@ -19,26 +19,22 @@ test("Default Settings", (t) => {
 		t.fail("Next should not be called");
 	};
 
-	middleware({method: "GET", path: "/test.html", headers: {}, query: {}}, res, next);
+	middleware({method: "GET", url: "/test.html", headers: {}}, res, next);
 	middleware({
 		method: "GET",
-		path: "/test.html",
-		headers: {},
-		query: {
-			"sap-ui-xx-csp-policy": "sap-target-level-2"
-		}
+		url: "/test.html?sap-ui-xx-csp-policy=sap-target-level-2",
+		headers: {}
 	}, res, next);
-	middleware({method: "POST", path: "somePath", headers: {}, query: {}}, res, next);
+	middleware({method: "POST", url: "somePath", headers: {}}, res, next);
 	middleware({
 		method: "POST",
-		path: "/dummy.csplog",
-		headers: {"content-type": "application/csp-report"},
-		query: {}
+		url: "/dummy.csplog",
+		headers: {"content-type": "application/csp-report"}
 	}, res, noNext);
 
 	// check that unsupported methods result in a call to next()
 	["CONNECT", "DELETE", "HEAD", "OPTIONS", "PATCH", "PUT", "TRACE"].forEach(
-		(method) => middleware({method, path: "/dummy.csplog", headers: {}, query: {}}, res, next)
+		(method) => middleware({method, url: "/dummy.csplog", headers: {}}, res, next)
 	);
 });
 
@@ -74,13 +70,13 @@ test("Custom Settings", (t) => {
 	};
 
 	expected = ["default-src 'self';", "default-src http:;"];
-	middleware({method: "GET", path: "/test.html", headers: {}, query: {}}, res, next);
+	middleware({method: "GET", url: "/test.html", headers: {}}, res, next);
 
 	expected = ["default-src https:;", "default-src http:;"];
-	middleware({method: "GET", path: "/test.html", headers: {}, query: {"csp": "policy3"}}, res, next);
+	middleware({method: "GET", url: "/test.html?csp=policy3", headers: {}}, res, next);
 
 	expected = ["default-src ftp:;", "default-src http:;"];
-	middleware({method: "GET", path: "/test.html", headers: {}, query: {"csp": "default-src ftp:;"}}, res, next);
+	middleware({method: "GET", url: "/test.html?csp=default-src%20ftp:;", headers: {}}, res, next);
 });
 
 test("No Dynamic Policy Definition", (t) => {
@@ -112,7 +108,7 @@ test("No Dynamic Policy Definition", (t) => {
 	};
 
 	const expected = ["default-src 'self';", "default-src http:;"];
-	middleware({method: "GET", path: "/test.html", headers: {}, query: {"csp": "default-src ftp:;"}}, res, next);
+	middleware({method: "GET", url: "/test.html?csp=default-src%20ftp:;", headers: {}}, res, next);
 });
 
 test("Header Manipulation", (t) => {
@@ -141,6 +137,6 @@ test("Header Manipulation", (t) => {
 	};
 	const next = function() {};
 
-	middleware({method: "GET", path: "/test.html", headers: {}, query: {}}, res, next);
+	middleware({method: "GET", url: "/test.html", headers: {}}, res, next);
 	t.deepEqual(cspHeader, ["default-src: spdy:", "default-src 'self';", "default-src http:;"]);
 });


### PR DESCRIPTION
With change 4f059670306c97ab5f34d82bb335f5ee21d73c72, the CSP middleware
made use of 'express' APIs on the request object. When used in an
environment without 'express' (e.g. the OpenUI5 legacy grunt tooling),
the CSP middleware failed for all requests.

It now uses the native NodeJS APIs again.

Fixes https://github.com/SAP/ui5-server/issues/183 .

**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [ ] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
