### PR TITLE
[INTERNAL] Change resource collections provided to the server middleware

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -117,20 +117,16 @@ module.exports = {
 		return Promise.resolve().then(() => {
 			const projectResourceCollections = resourceFactory.createCollectionsForTree(tree);
 
-			const workspace = resourceFactory.createWorkspace({
-				reader: projectResourceCollections.source,
-				name: tree.metadata.name
+			const combo = new ReaderCollectionPrioritized({
+				name: "server - prioritize source over dependencies",
+				readers: [projectResourceCollections.source, projectResourceCollections.dependencies]
 			});
 
-			const combo = new ReaderCollectionPrioritized({
-				name: "server - prioritize workspace over dependencies",
-				readers: [workspace, projectResourceCollections.dependencies]
-			});
 
 			const resourceCollections = {
-				source: projectResourceCollections.source,
+				all: combo,
+				rootProject: projectResourceCollections.source,
 				dependencies: projectResourceCollections.dependencies,
-				combo
 			};
 
 			const app = express();


### PR DESCRIPTION
The `workspace` created by the `resourceFactory` is removed, since the created `DuplexCollection` with a `MemAdapter` is not required. Instead, a `ReaderCollectionPrioritized` is created to use the provided source and the dependencies.

**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [x] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
