### PR TITLE
[INTERNAL] Adapt tests to new behavior of FileSystem._runGlob which now throws for GLOB errors

### DIFF
--- a/test/lib/server/middleware/serveIndex.js
+++ b/test/lib/server/middleware/serveIndex.js
@@ -1,4 +1,3 @@
-const path = require("path");
 const {test} = require("ava");
 const resourceFactory = require("@ui5/fs").resourceFactory;
 
@@ -19,26 +18,20 @@ test.serial("Check if index for files is created", (t) => {
 		return writer.write(resource);
 	};
 
-	const filePath = path.join(process.cwd(), "./test/tmp/");
-	const reader = resourceFactory.createAdapter({fsBasePath: filePath, virBasePath: "/"});
-	const writer = resourceFactory.createAdapter({virBasePath: "/"});
-	const workspace = resourceFactory.createWorkspace({
-		reader: reader,
-		writer: writer
-	});
+	const readerWriter = resourceFactory.createAdapter({virBasePath: "/"});
 
 	return Promise.all([
-		writeResource(writer, "/myFile1.meh", 1024), // KB
-		writeResource(writer, "/myFile2.js", 1024 * 1024), // MB
-		writeResource(writer, "/myFile3.properties", 1024 * 1024 * 1024), // GB
+		writeResource(readerWriter, "/myFile1.meh", 1024), // KB
+		writeResource(readerWriter, "/myFile2.js", 1024 * 1024), // MB
+		writeResource(readerWriter, "/myFile3.properties", 1024 * 1024 * 1024), // GB
 	]).then(() => {
 		const middleware = serveIndexMiddleware({
 			resourceCollections: {
-				combo: workspace
+				combo: readerWriter
 			}
 		});
 
-		return new Promise((resolve) => {
+		return new Promise((resolve, reject) => {
 			const req = {
 				path: "/"
 			};
@@ -52,7 +45,8 @@ test.serial("Check if index for files is created", (t) => {
 					resolve();
 				},
 			};
-			const next = function() {
+			const next = function(err) {
+				reject(new Error(`Next callback called with error: ${err.message}`));
 			};
 			middleware(req, res, next);
 		});


### PR DESCRIPTION
See https://github.com/SAP/ui5-fs/pull/140

The tmp directory might not be present during the execution of this
test. However, its usage didn't really add any value to the test
anyways.