### PR TITLE
[PoC| Proxy Mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 module.exports = {
 	server: require("./lib/server"),
 	sslUtil: require("./lib/sslUtil"),
+	proxyConfiguration: require("./lib/proxyConfiguration"),
 	middlewareRepository: require("./lib/middleware/middlewareRepository"),
 
 	// Legacy middleware export. Still private.

--- a/lib/middleware/MiddlewareManager.js
+++ b/lib/middleware/MiddlewareManager.js
@@ -1,4 +1,6 @@
 const middlewareRepository = require("./middlewareRepository");
+const proxyConfiguration = require("../proxyConfiguration");
+
 /**
  *
  *
@@ -6,7 +8,8 @@ const middlewareRepository = require("./middlewareRepository");
  */
 class MiddlewareManager {
 	constructor({tree, resources, options = {
-		sendSAPTargetCSP: false
+		sendSAPTargetCSP: false,
+		useProxy: false
 	}}) {
 		if (!tree || !resources || !resources.all || !resources.rootProject || !resources.dependencies) {
 			throw new Error("[MiddlewareManager]: One or more mandatory parameters not provided");
@@ -64,6 +67,13 @@ class MiddlewareManager {
 	}
 
 	async addStandardMiddleware() {
+		const useProxy = this.options.useProxy;
+
+		let proxyConfig;
+		if (useProxy) {
+			proxyConfig = await proxyConfiguration.getConfigurationForProject(this.tree);
+		}
+
 		await this.addMiddleware("csp", {
 			wrapperCallback: (cspModule) => {
 				const oCspConfig = {
@@ -105,6 +115,21 @@ class MiddlewareManager {
 		});
 		await this.addMiddleware("compression");
 		await this.addMiddleware("cors");
+
+		if (useProxy) {
+			await this.addMiddleware("proxyRewrite", {
+				wrapperCallback: (proxyRewriteModule) => {
+					return ({resources}) => {
+						return proxyRewriteModule({
+							resources,
+							configuration: proxyConfig,
+							cdnUrl: this.options.cdnUrl
+						});
+					};
+				}
+			});
+		}
+
 		await this.addMiddleware("discovery", {
 			mountPath: "/discovery"
 		});
@@ -121,13 +146,44 @@ class MiddlewareManager {
 				};
 			}
 		});
-		await this.addMiddleware("connectUi5Proxy", {
-			mountPath: "/proxy"
-		});
+
+		if (this.options.cdnUrl) {
+			await this.addMiddleware("cdn", {
+				wrapperCallback: (cdn) => {
+					return ({resources}) => {
+						return cdn({
+							resources,
+							cdnUrl: this.options.cdnUrl
+						});
+					};
+				}
+			});
+		}
+
+		if (useProxy) {
+			await this.addMiddleware("proxy", {
+				wrapperCallback: (proxyModule) => {
+					return ({resources}) => {
+						return proxyModule({
+							resources,
+							configuration: proxyConfig
+						});
+					};
+				}
+			});
+		} else {
+			await this.addMiddleware("connectUi5Proxy", {
+				mountPath: "/proxy"
+			});
+		}
+
 		// Handle anything but read operations *before* the serveIndex middleware
 		//	as it will reject them with a 405 (Method not allowed) instead of 404 like our old tooling
 		await this.addMiddleware("nonReadRequests");
-		await this.addMiddleware("serveIndex");
+		if (!useProxy) {
+			// Don't do directory listing when using a proxy. High potential for confusion
+			await this.addMiddleware("serveIndex");
+		}
 	}
 
 	async addCustomMiddleware() {

--- a/lib/middleware/cdn.js
+++ b/lib/middleware/cdn.js
@@ -1,0 +1,99 @@
+const log = require("@ui5/logger").getLogger("server:middleware:cdn");
+const http = require("http");
+const https = require("https");
+
+function createMiddleware({cdnUrl}) {
+	if (!cdnUrl) {
+		throw new Error(`Missing parameter "cdnUrl"`);
+	}
+	if (cdnUrl.endsWith("/")) {
+		throw new Error(`Parameter "cdnUrl" must not end with a slash`);
+	}
+
+	return function proxy(req, res, next) {
+		if (req.method !== "GET" && req.method !== "HEAD" && req.method !== "OPTIONS") {
+			// Cannot be fulfilled by CDN
+			next();
+			return;
+		}
+
+		log.verbose(`Requesting ${req.url} from CDN ${cdnUrl}...`);
+		log.verbose(`Orig. URL: ${req.originalUrl}`);
+
+		getResource({
+			cdnUrl,
+			resourcePath: req.url,
+			resolveOnOddStatusCode: true,
+			headers: req.headers
+		}).then(({data, headers, statusCode}) => {
+			if (statusCode !== 200) {
+				// odd status code
+				log.verbose(`CDN replied with status code ${statusCode} for request ${req.url}`);
+				next();
+				return;
+			}
+			if (headers) {
+				for (const headerKey in headers) {
+					if (headers.hasOwnProperty(headerKey)) {
+						res.setHeader(headerKey, headers[headerKey]);
+					}
+				}
+			}
+
+			res.setHeader("x-ui5-tooling-proxied-from-cdn", cdnUrl);
+			res.setHeader("x-ui5-tooling-proxied-as", req.url);
+
+			res.send(data);
+		}).catch((err) => {
+			log.error(`CDN request error: ${err.message}`);
+			next(err);
+		});
+	};
+}
+
+const cache = {};
+
+function getResource({cdnUrl, resourcePath, resolveOnOddStatusCode, headers}) {
+	return new Promise((resolve, reject) => {
+		const reqUrl = cdnUrl + resourcePath;
+		if (cache[reqUrl]) {
+			resolve(cache[reqUrl]);
+		}
+		if (!cdnUrl.startsWith("http")) {
+			throw new Error(`CDN URL must start with protocol "http" or "https": ${cdnUrl}`);
+		}
+		let client = http;
+		if (cdnUrl.startsWith("https")) {
+			client = https;
+		}
+		client.get(reqUrl, (cdnResponse) => {
+			const {statusCode} = cdnResponse;
+
+			const data = [];
+			cdnResponse.on("data", (chunk) => {
+				data.push(chunk);
+			});
+			cdnResponse.on("end", () => {
+				try {
+					const result = {
+						data: Buffer.concat(data),
+						statusCode,
+						headers: cdnResponse.headers
+					};
+					cache[reqUrl] = result;
+					if (Object.keys(cache).length % 10 === 0) {
+						log.verbose(`Cache size: ${Object.keys(cache).length} entries`);
+					}
+					resolve(result);
+				} catch (err) {
+					reject(err);
+				}
+			});
+		}).on("error", (err) => {
+			reject(err);
+		});
+	});
+}
+
+module.exports = createMiddleware;
+module.exports.getResource = getResource;

--- a/lib/middleware/middlewareRepository.js
+++ b/lib/middleware/middlewareRepository.js
@@ -2,13 +2,16 @@ const middlewares = {
 	compression: "compression",
 	cors: "cors",
 	csp: "./csp",
+	cdn: "./cdn",
 	serveResources: "./serveResources",
 	serveIndex: "./serveIndex",
 	discovery: "./discovery",
 	versionInfo: "./versionInfo",
 	connectUi5Proxy: "./connectUi5Proxy",
 	serveThemes: "./serveThemes",
-	nonReadRequests: "./nonReadRequests"
+	nonReadRequests: "./nonReadRequests",
+	proxy: "./proxy",
+	proxyRewrite: "./proxyRewrite"
 };
 
 function getMiddleware(middlewareName) {

--- a/lib/middleware/proxy.js
+++ b/lib/middleware/proxy.js
@@ -1,0 +1,55 @@
+const log = require("@ui5/logger").getLogger("server:middleware:proxy");
+const httpProxy = require("http-proxy");
+
+function createMiddleware({configuration}) {
+	let agent;
+
+	if (configuration.forwardProxy) {
+		let username = configuration.forwardProxy.username;
+		let password = configuration.forwardProxy.password;
+		if (!username) {
+			// TODO prompt user for credentials
+			username = "";
+		}
+		if (!password) {
+			// TODO prompt user for credentials
+			password = "";
+		}
+		const HttpsProxyAgent = require("https-proxy-agent");
+		agent = new HttpsProxyAgent({
+			host: configuration.forwardProxy.hostname,
+			port: configuration.forwardProxy.port,
+			secureProxy: configuration.forwardProxy.useSsl,
+			auth: username + ":" + password
+		});
+	}
+
+	const proxyServer = httpProxy.createProxyServer({
+		agent: agent,
+		secure: !configuration.insecure,
+		prependPath: false,
+		xfwd: true,
+		target: configuration.destination.origin,
+		changeOrigin: true
+	});
+
+	proxyServer.on("proxyRes", function(proxyRes, req, res) {
+		res.setHeader("x-ui5-tooling-proxied-from", configuration.destination.origin);
+	});
+
+	return function proxy(req, res, next) {
+		if (req.url !== req.originalUrl) {
+			log.verbose(`Proxying "${req.url}"`); // normalized URL - used for local resolution
+			log.verbose(`      as "${req.originalUrl}"`); // original URL - used for reverse proxy requests
+		} else {
+			log.verbose(`Proxying "${req.url}"`);
+		}
+		req.url = req.originalUrl; // Always use the original (non-rewritten) URL
+		proxyServer.web(req, res, (err) => {
+			log.error(`Proxy error: ${err.message}`);
+			next(err);
+		});
+	};
+}
+
+module.exports = createMiddleware;

--- a/lib/middleware/proxyRewrite.js
+++ b/lib/middleware/proxyRewrite.js
@@ -1,14 +1,17 @@
 const log = require("@ui5/logger").getLogger("server:middleware:proxyRewrite");
 
 function createMiddleware({resources, configuration, cdnUrl}) {
-	const resourceRootPath = !configuration.appOnly && configuration.destination.ui5Root;
-	const applicationRootPath = configuration.destination.appRoot;
+	const rewriteRootPaths = configuration.rewriteRootPaths;
+
 	const cacheBusterRegex = /~.*~[A-Z0-9]?\/?/;
 	const preloadRegex = /^.*(?:Component-preload\.js|library-preload\.js|library-preload\.json)$/i;
 
 	return function proxyRewrite(req, res, next) {
-		if ((!resourceRootPath || req.path.indexOf(resourceRootPath) === -1) &&
-				(!applicationRootPath || req.path.indexOf(applicationRootPath) === -1)) {
+		const rewriteApplicable = Object.keys(rewriteRootPaths).some((resourceRootPath) => {
+			return req.path.indexOf(resourceRootPath) !== -1;
+		});
+
+		if (!rewriteApplicable) {
 			// No normalization applicable
 			next();
 			return;
@@ -82,14 +85,19 @@ function createMiddleware({resources, configuration, cdnUrl}) {
 	async function normalizeRequestPath(reqPath) {
 		let normalizedPath = reqPath;
 
-		if (resourceRootPath && normalizedPath.indexOf(resourceRootPath) !== -1) {
-			normalizedPath = normalizedPath.substr(resourceRootPath.length);
-		} else if (applicationRootPath && normalizedPath.indexOf(applicationRootPath) !== -1) {
-			normalizedPath = normalizedPath.substr(applicationRootPath.length);
+		// Strip off first matching rewrite root path
+		for (const rootPath in rewriteRootPaths) {
+			if (rewriteRootPaths.hasOwnProperty(rootPath)) {
+				if (normalizedPath.indexOf(rootPath) !== -1) {
+					normalizedPath = normalizedPath.substr(rootPath.length);
+					if (rewriteRootPaths[rootPath].rewriteTo) {
+						normalizedPath = rewriteRootPaths[rootPath].rewriteTo + normalizedPath;
+					}
+					break;
+				}
+			}
 		}
-
 		normalizedPath = normalizedPath.replace(cacheBusterRegex, "");
-
 		return rewriteSpecials(normalizedPath);
 	}
 

--- a/lib/middleware/proxyRewrite.js
+++ b/lib/middleware/proxyRewrite.js
@@ -1,0 +1,236 @@
+const log = require("@ui5/logger").getLogger("server:middleware:proxyRewrite");
+
+function createMiddleware({resources, configuration, cdnUrl}) {
+	const resourceRootPath = !configuration.appOnly && configuration.destination.ui5Root;
+	const applicationRootPath = configuration.destination.appRoot;
+	const cacheBusterRegex = /~.*~[A-Z0-9]?\/?/;
+	const preloadRegex = /^.*(?:Component-preload\.js|library-preload\.js|library-preload\.json)$/i;
+
+	return function proxyRewrite(req, res, next) {
+		if ((!resourceRootPath || req.path.indexOf(resourceRootPath) === -1) &&
+				(!applicationRootPath || req.path.indexOf(applicationRootPath) === -1)) {
+			// No normalization applicable
+			next();
+			return;
+		}
+
+		log.verbose(`Normalizing ${req.path}...`);
+		// Normalize URL
+		normalizeRequestPath(req.path)
+			.catch((err) => {
+				log.error(`Failed to normalize ${req.path}. Error ${err.message}`);
+				return "";
+			})
+			.then((normalizedUrl) => {
+				req.url = req.url.replace(req.path, normalizedUrl);
+				log.verbose(`Normalized ${req.originalUrl}`);
+				log.verbose(`        to ${req.url}`); // will be used for internal resolution
+				handleSpecialRequests(req, res, next);
+			});
+	};
+
+	function handleSpecialRequests(req, res, next) {
+		switch (req.url) {
+		case "special:404":
+			res.setHeader("x-ui5-tooling-special-request-handling", req.url);
+			res.status(404).end("UI5 Tooling - Proxy Rewrite Middleware: Special request handling " +
+					`blocked this request by returning status code 404 - Not Found`);
+			break;
+		case "special:empty":
+			res.setHeader("x-ui5-tooling-special-request-handling", req.url);
+			res.end("// UI5 Tooling - Proxy Rewrite Middleware: " +
+				"Special request handling blocked this request by returning no file content");
+			break;
+		case "special:sap-ui-core-bootstrap":
+			getResources(["/resources/ui5loader-autoconfig.js"]).then(async ([autoconfigLoaderResource]) => {
+				let bootstrap;
+				if (autoconfigLoaderResource) {
+					bootstrap = await getBootstrapFile("evo-core");
+				} else {
+					bootstrap = await getBootstrapFile("classic-core");
+				}
+				res.setHeader("Content-Type", "application/javascript");
+				res.setHeader("x-ui5-tooling-special-request-handling", req.url);
+				res.end(bootstrap);
+			}).catch((err) => {
+				const errMsg = `Failed to generate bootstrap file for request ${req.originalUrl} (${req.url}). ` +
+					`Error: ${err.message}`;
+				log.error(errMsg);
+				log.error(err.stack);
+				next(errMsg);
+			});
+			break;
+		case "special:flp-abap-bootstrap":
+			getBootstrapFile("flp-abap").then((bootstrap) => {
+				res.setHeader("Content-Type", "application/javascript");
+				res.setHeader("x-ui5-tooling-special-request-handling", req.url);
+				res.end(bootstrap);
+			}).catch((err) => {
+				const errMsg = `Failed to generate bootstrap file for request ${req.originalUrl} (${req.url}). ` +
+					`Error: ${err.message}`;
+				log.error(errMsg);
+				log.error(err.stack);
+				next(errMsg);
+			});
+			break;
+		default:
+			next();
+			break;
+		}
+	}
+
+	async function normalizeRequestPath(reqPath) {
+		let normalizedPath = reqPath;
+
+		if (resourceRootPath && normalizedPath.indexOf(resourceRootPath) !== -1) {
+			normalizedPath = normalizedPath.substr(resourceRootPath.length);
+		} else if (applicationRootPath && normalizedPath.indexOf(applicationRootPath) !== -1) {
+			normalizedPath = normalizedPath.substr(applicationRootPath.length);
+		}
+
+		normalizedPath = normalizedPath.replace(cacheBusterRegex, "");
+
+		return rewriteSpecials(normalizedPath);
+	}
+
+	async function rewriteSpecials(normalizedPath) {
+		switch (normalizedPath) {
+		/* === FLP bootstrap === */
+		case "/resources/sap/fiori/core-min-0.js":
+			// Try to serve sap-ui-core.js instead
+			return "/resources/sap-ui-core.js";
+		case "/resources/sap/fiori/core-min-1.js":
+		case "/resources/sap/fiori/core-min-2.js":
+		case "/resources/sap/fiori/core-min-3.js":
+			// Send an empty file
+			return "special:empty";
+
+		/* === FLP evo bootstrap === */
+		case "/resources/sap/ushell_abap/bootstrap/evo/abap.js":
+			return "special:flp-abap-bootstrap";
+		case "/resources/sap/ushell_abap/bootstrap/evo/core-min-0.js":
+			// Try to serve sap-ui-core.js instead
+			return "/resources/sap-ui-core.js";
+		case "/resources/sap/ushell_abap/bootstrap/evo/core-min-1.js":
+		case "/resources/sap/ushell_abap/bootstrap/evo/core-min-2.js":
+		case "/resources/sap/ushell_abap/bootstrap/evo/core-min-3.js":
+			// Send an empty file
+			return "special:empty";
+
+		case "/resources/sap/fiori/core-ext-light-0.js":
+			// Try to serve sap-ui-core.js instead
+			// return "special:flp-abap-bootstrap";
+			return "special:empty";
+		case "/resources/sap/fiori/core-ext-light-1.js":
+		case "/resources/sap/fiori/core-ext-light-2.js":
+		case "/resources/sap/fiori/core-ext-light-3.js":
+			// Send an empty file
+			return "special:empty";
+
+		/* === C4C (and others?) bootstrap === */
+		case "/resources/sap/client/lib-0.js":
+			// Try to serve compiled sap-ui-core.js instead
+			return "special:sap-ui-core-bootstrap";
+		case "/resources/sap/client/lib-1.js":
+		case "/resources/sap/client/lib-2.js":
+		case "/resources/sap/client/lib-3.js":
+		case "/resources/sap/client/lib-thirdparty.js":
+		case "/resources/sap/client/lib-deprecated.js":
+			// Send an empty file
+			return "special:empty";
+		}
+
+		/* === Preloads === */
+		if (preloadRegex.test(normalizedPath)) {
+			// return "special:404";
+			return "special:empty";
+		}
+
+		return normalizedPath;
+	}
+
+	function getBootstrapFile(style) {
+		let resourceList;
+		let post;
+
+		switch (style) {
+		case "evo-core":
+			resourceList = [
+				"/resources/sap/ui/thirdparty/es6-promise.js",
+				"/resources/sap/ui/thirdparty/es6-string-methods.js",
+				"/resources/ui5loader.js",
+				"/resources/ui5loader-autoconfig.js"
+			];
+
+			post = "\n\nsap.ui.requireSync(\"sap/ui/core/Core\"); sap.ui.getCore().boot();";
+			break;
+		case "classic-core":
+			resourceList = [
+				"/resources/sap/ui/thirdparty/jquery.js",
+				"/resources/sap/ui/thirdparty/jqueryui/jquery-ui-position.js",
+				"/resources/sap/ui/Device.js",
+				"/resources/sap/ui/thirdparty/URI.js",
+				"/resources/sap/ui/thirdparty/es6-promise.js",
+				"/resources/jquery.sap.global.js",
+				"/resources/sap/ui/core/Core.js"
+			];
+
+			post = "\n\njQuery.sap.require(\"sap/ui/core/Core\"); " +
+					"sap.ui.getCore().boot && sap.ui.getCore().boot();";
+			break;
+		case "flp-abap":
+			resourceList = [
+				"/resources/sap/ui/thirdparty/baseuri.js",
+				"/resources/sap/ui/thirdparty/es6-promise.js",
+				"/resources/sap/ui/thirdparty/es6-string-methods.js",
+				"/resources/sap/ui/thirdparty/es6-object-assign.js",
+				"/resources/sap/ui/thirdparty/es6-shim-nopromise.js",
+				"/resources/ui5loader.js",
+				"/resources/sap/ushell/bootstrap/ui5loader-config.js",
+				"/resources/ui5loader-autoconfig.js"
+			];
+
+			post = `sap.ui.requireSync("sap/ushell_abap/bootstrap/evo/abap-def-dev");
+sap.ui.requireSync("sap/ui/core/Core"); sap.ui.getCore().boot();
+
+// ComponentContainer Required in case of deep links.
+// Possibly because of missing require in ushell/services/Container.js?
+sap.ui.requireSync("sap/ui/core/ComponentContainer");`;
+			break;
+		default:
+			throw new Error(`Unkown bootstrap file style ${style}`);
+		}
+
+		return getResources(resourceList).then((strings) => {
+			const pre = `/* ==== Generated file ui5-evo server ${new Date().toString()}==== */\n\n`;
+			const joinedFiles = strings.join("\n\n");
+			return pre + joinedFiles + post;
+		});
+	}
+
+	function getResources(resourceList) {
+		if (cdnUrl) {
+			const cdn = require("./cdn");
+			return Promise.all(resourceList.map(async (resourcePath) => {
+				const {data, statusCode} = await cdn.getResource({cdnUrl, resourcePath});
+				if (statusCode !== 200) {
+					throw new Error(`CDN replied with status code ${statusCode} for request ${resourcePath}`);
+				}
+				return data;
+			}));
+		} else {
+			return Promise.all(resourceList.map((resourcePath) => {
+				return resources.all.byPath(resourcePath).then((resource) => {
+					if (!resource) {
+						throw new Error(`Could not find resource ${resourcePath} on local host`);
+					}
+					return resource.getBuffer().then((buffer) => {
+						return `/* Begin of ${resource.virtualPath} */\n\n` + buffer.toString();
+					});
+				});
+			}));
+		}
+	}
+}
+
+module.exports = createMiddleware;

--- a/lib/middleware/serveResources.js
+++ b/lib/middleware/serveResources.js
@@ -56,6 +56,7 @@ function createMiddleware({resources}) {
 			if (!res.getHeader("Content-Type")) {
 				res.setHeader("Content-Type", type + (charset ? "; charset=" + charset : ""));
 			}
+			res.setHeader("x-ui5-tooling-served-from-host", true);
 
 			// Enable ETag caching
 			res.setHeader("ETag", etag(resource.getStatInfo()));

--- a/lib/middleware/serveThemes.js
+++ b/lib/middleware/serveThemes.js
@@ -1,3 +1,4 @@
+const log = require("@ui5/logger").getLogger("server:middleware:serveThemes");
 const themeBuilder = require("@ui5/builder").processors.themeBuilder;
 const fsInterface = require("@ui5/fs").fsInterface;
 const etag = require("etag");
@@ -63,7 +64,9 @@ function createMiddleware({resources}) {
 					res.setHeader("Content-Type", "application/json");
 					resource = parameters;
 				} else {
-					next("Couldn't decide on which theme file to return. This shouldn't happen");
+					const errorMessage = "Couldn't decide on which theme file to return. This shouldn't happen";
+					log.error(errorMessage);
+					next(errorMessage);
 					return;
 				}
 
@@ -81,6 +84,7 @@ function createMiddleware({resources}) {
 				});
 			});
 		}).catch(function(err) {
+			log.error(`Failed to process request for ${pathname}. Error: ${err.message}`);
 			next(err);
 		});
 	};

--- a/lib/proxyConfiguration.js
+++ b/lib/proxyConfiguration.js
@@ -19,7 +19,7 @@ function addConfiguration(name, proxyConfig) {
 	proxyConfigurations[name] = proxyConfig;
 }
 
-async function getConfigurationForProject(project) {
+async function getConfigurationForProject(tree) {
 	const configNames = Object.keys(proxyConfigurations);
 	if (configNames.length === 0) {
 		throw new Error(`No proxy configurations have been added yet`);
@@ -29,7 +29,7 @@ async function getConfigurationForProject(project) {
 			`This is not yet supported.`); // TODO
 	}
 
-	log.verbose(`Applying proxy configuration ${configNames[0]} to project ${project.metadata.name}...`);
+	log.verbose(`Applying proxy configuration ${configNames[0]} to project ${tree.metadata.name}...`);
 	const config = JSON.parse(JSON.stringify(proxyConfigurations[configNames[0]]));
 	config.rewriteRootPaths = {};
 
@@ -40,15 +40,15 @@ async function getConfigurationForProject(project) {
 		};
 	}
 
-	mapProjectDependencies(project, (proj) => {
-		if (proj.specVersion !== "1.1a") {
-			log.warn(`Project ${project.metadata.name} defines specification version ${proj.specVersion}. ` +
+	mapProjectDependencies(tree, (project) => {
+		if (project.specVersion !== "1.1a") {
+			log.warn(`Project ${project.metadata.name} defines specification version ${project.specVersion}. ` +
 				`Some proxy configuration features require projects to define specification version 1.1a`);
 		}
-		log.verbose(`Using ABAP URI ${proj.metadata.abapUri} from metadata of project ${proj.metadata.name}`);
+		log.verbose(`Using ABAP URI ${project.metadata.abapUri} from metadata of project ${project.metadata.name}`);
 		let prefix = "";
-		if (proj.type !== "application") {
-			if (project.resources.pathMappings["/resources"]) {
+		if (project.type !== "application") {
+			if (project.resources.pathMappings["/resources/"]) {
 				// If the project defines a /resources path mapping,
 				//	we expect this to match the ABAP URI deployment path
 				prefix += "/resources/";
@@ -56,16 +56,16 @@ async function getConfigurationForProject(project) {
 				// If this is not an application and there is no /resources path mapping, somebody does something wild
 				//	and hopefully knows what he/she does
 			}
-			prefix += proj.metadata.namespace;
+			prefix += project.metadata.namespace;
 		}
-		config.rewriteRootPaths[proj.metadata.abapUri] = {
+		config.rewriteRootPaths[project.metadata.abapUri] = {
 			rewriteTo: prefix
 		};
 	});
 
 	if (log.isLevelEnabled("verbose")) {
-		log.verbose(`Configured ${config.rewriteRootPaths.length} root paths to rewrite for ` +
-			`project ${project.metadata.name};`);
+		log.verbose(`Configured ${Object.keys(config.rewriteRootPaths).length} root paths to rewrite for ` +
+			`project ${tree.metadata.name};`);
 		for (const abapUri in config.rewriteRootPaths) {
 			if (config.rewriteRootPaths.hasOwnProperty(abapUri)) {
 				if (config.rewriteRootPaths[abapUri].rewriteTo) {

--- a/lib/proxyConfiguration.js
+++ b/lib/proxyConfiguration.js
@@ -1,5 +1,4 @@
-const log = require("@ui5/logger").getLogger("proxyConfiguration");
-const {resourceFactory} = require("@ui5/fs");
+const log = require("@ui5/logger").getLogger("server:proxyConfiguration");
 
 const proxyConfigurations = {};
 
@@ -9,6 +8,9 @@ function addConfiguration(name, proxyConfig) {
 	}
 	if (proxyConfigurations[name]) {
 		throw new Error(`proxyConfiguration: A configuration with name ${name} is already known`);
+	}
+	if (proxyConfig.rewriteRootPaths) {
+		throw new Error(`Proxy Configuration ${name} must not define "rewriteRootPaths"`);
 	}
 
 	if (!proxyConfig.destination) {
@@ -26,21 +28,63 @@ async function getConfigurationForProject(project) {
 		throw new Error(`Found multiple proxy configurations. ` +
 			`This is not yet supported.`); // TODO
 	}
-	const config = JSON.parse(JSON.stringify(proxyConfigurations[configNames[0]]));
 
-	const {source} = resourceFactory.createCollectionsForTree(project);
-	const manifestResource = await source.byPath("/manifest.json");
-	if (manifestResource) {
-		const manifest = JSON.parse(await manifestResource.getBuffer());
-		if (manifest["sap.platform.abap"] && manifest["sap.platform.abap"].uri) {
-			log.verbose(`Using sap.platform.abap URI configuration as application root ` +
-				`path: ${manifest["sap.platform.abap"].uri}`);
-			config.destination.appRoot = manifest["sap.platform.abap"].uri;
+	log.verbose(`Applying proxy configuration ${configNames[0]} to project ${project.metadata.name}...`);
+	const config = JSON.parse(JSON.stringify(proxyConfigurations[configNames[0]]));
+	config.rewriteRootPaths = {};
+
+	if (config.destination.ui5Root && !config.appOnly) {
+		log.verbose(`Using configured "destination.ui5Root": ${config.destination.ui5Root}`);
+		config.rewriteRootPaths[config.destination.ui5Root] = {
+			rewriteTo: ""
+		};
+	}
+
+	mapProjectDependencies(project, (proj) => {
+		if (proj.specVersion !== "1.1a") {
+			log.warn(`Project ${project.metadata.name} defines specification version ${proj.specVersion}. ` +
+				`Some proxy configuration features require projects to define specification version 1.1a`);
+		}
+		log.verbose(`Using ABAP URI ${proj.metadata.abapUri} from metadata of project ${proj.metadata.name}`);
+		let prefix = "";
+		if (proj.type !== "application") {
+			if (project.resources.pathMappings["/resources"]) {
+				// If the project defines a /resources path mapping,
+				//	we expect this to match the ABAP URI deployment path
+				prefix += "/resources/";
+
+				// If this is not an application and there is no /resources path mapping, somebody does something wild
+				//	and hopefully knows what he/she does
+			}
+			prefix += proj.metadata.namespace;
+		}
+		config.rewriteRootPaths[proj.metadata.abapUri] = {
+			rewriteTo: prefix
+		};
+	});
+
+	if (log.isLevelEnabled("verbose")) {
+		log.verbose(`Configured ${config.rewriteRootPaths.length} root paths to rewrite for ` +
+			`project ${project.metadata.name};`);
+		for (const abapUri in config.rewriteRootPaths) {
+			if (config.rewriteRootPaths.hasOwnProperty(abapUri)) {
+				if (config.rewriteRootPaths[abapUri].rewriteTo) {
+					log.verbose(`Rewriting ${abapUri} to ${config.rewriteRootPaths[abapUri].rewriteTo}`);
+				} else {
+					log.verbose(`Rewriting ${abapUri}`);
+				}
+			}
 		}
 	}
-	log.verbose(`UI5 root path configured as: ${config.destination.ui5Root}`);
 
 	return config;
+}
+
+function mapProjectDependencies(tree, handler) {
+	handler(tree);
+	tree.dependencies.map((dep) => {
+		mapProjectDependencies(dep, handler);
+	});
 }
 
 module.exports = {

--- a/lib/proxyConfiguration.js
+++ b/lib/proxyConfiguration.js
@@ -1,0 +1,49 @@
+const log = require("@ui5/logger").getLogger("proxyConfiguration");
+const {resourceFactory} = require("@ui5/fs");
+
+const proxyConfigurations = {};
+
+function addConfiguration(name, proxyConfig) {
+	if (!name || !proxyConfig) {
+		throw new Error(`proxyConfiguration: Function called with missing parameters`);
+	}
+	if (proxyConfigurations[name]) {
+		throw new Error(`proxyConfiguration: A configuration with name ${name} is already known`);
+	}
+
+	if (!proxyConfig.destination) {
+		proxyConfig.destination = {};
+	}
+	proxyConfigurations[name] = proxyConfig;
+}
+
+async function getConfigurationForProject(project) {
+	const configNames = Object.keys(proxyConfigurations);
+	if (configNames.length === 0) {
+		throw new Error(`No proxy configurations have been added yet`);
+	}
+	if (configNames.length > 1) {
+		throw new Error(`Found multiple proxy configurations. ` +
+			`This is not yet supported.`); // TODO
+	}
+	const config = JSON.parse(JSON.stringify(proxyConfigurations[configNames[0]]));
+
+	const {source} = resourceFactory.createCollectionsForTree(project);
+	const manifestResource = await source.byPath("/manifest.json");
+	if (manifestResource) {
+		const manifest = JSON.parse(await manifestResource.getBuffer());
+		if (manifest["sap.platform.abap"] && manifest["sap.platform.abap"].uri) {
+			log.verbose(`Using sap.platform.abap URI configuration as application root ` +
+				`path: ${manifest["sap.platform.abap"].uri}`);
+			config.destination.appRoot = manifest["sap.platform.abap"].uri;
+		}
+	}
+	log.verbose(`UI5 root path configured as: ${config.destination.ui5Root}`);
+
+	return config;
+}
+
+module.exports = {
+	addConfiguration,
+	getConfigurationForProject
+};

--- a/lib/server.js
+++ b/lib/server.js
@@ -66,15 +66,21 @@ function _listen(app, port, changePortIfInUse, acceptRemoteConnections) {
  *
  * @param {Object} parameters
  * @param {Object} parameters.app The original express application
- * @param {string} parameters.key Path to private key to be used for https
- * @param {string} parameters.cert Path to certificate to be used for for https
+ * @param {string} parameters.key Private key to be used for https
+ * @param {string} parameters.cert Certificate to be used for for https
+ * @param {string} parameters.h2 Enables HTTP/2 protocol
  * @returns {Object} The express application with SSL support
  * @private
  */
-function _addSsl({app, key, cert}) {
-	// Using spdy as http2 server as the native http2 implementation
-	// from Node v8.4.0 doesn't seem to work with express
-	return require("spdy").createServer({cert, key}, app);
+function _addSsl({app, key, cert, h2}) {
+	if (h2) {
+		// Using spdy as http2 server as the native http2 implementation
+		// from Node v8.4.0 doesn't seem to work with express
+		return require("spdy").createServer({cert, key}, app);
+	} else {
+		// Just a plain HTTPS server
+		return require("https").createServer({key, cert}, app);
+	}
 }
 
 /**
@@ -91,24 +97,30 @@ module.exports = {
 	 * @param {Object} options Options
 	 * @param {number} options.port Port to listen to
 	 * @param {boolean} [options.changePortIfInUse=false] If true, change the port if it is already in use
-	 * @param {boolean} [options.h2=false] Whether HTTP/2 should be used - defaults to <code>http</code>
-	 * @param {string} [options.key] Path to private key to be used for https
-	 * @param {string} [options.cert] Path to certificate to be used for for https
+	 * @param {boolean} [options.h2=false] Whether HTTP/2 and HTTPS should be used
+	 * @param {boolean} [options.useProxy=false] Whether to use a proxy configured
+	 *												globally in the proxyConfiguration module
+	 * @param {string} [options.key] Private key to be used for https
+	 * @param {string} [options.cert] Certificate to be used for for https
 	 * @param {boolean} [options.acceptRemoteConnections=false] If true, listens to remote connections and
 	 * 															not only to localhost connections
 	 * @param {boolean} [options.sendSAPTargetCSP=false] If true, then the content security policies that SAP and UI5
 	 * 													aim for (AKA 'target policies'), are send for any requested
 	 * 													<code>*.html</code> file
 	 * @returns {Promise<Object>} Promise resolving once the server is listening.
+	 * @param {boolean} [options.cdnUrl] CDN base URL to use. There must be no trailing slash.
+	 *									Example: <code>https://sapui5.hana.ondemand.com/1.60.10</code>
+	 * @returns {Promise<Object>} Promise resolving once the server is listening.
 	 * 							It resolves with an object containing the <code>port</code>,
 	 * 							<code>h2</code>-flag and a <code>close</code> function,
 	 * 							which can be used to stop the server.
 	 */
 	async serve(tree, {
-		port: requestedPort, changePortIfInUse = false, h2 = false, key, cert,
-		acceptRemoteConnections = false, sendSAPTargetCSP = false}) {
-		const projectResourceCollections = resourceFactory.createCollectionsForTree(tree);
+		port: requestedPort, changePortIfInUse = false, h2 = false, useProxy = false, key, cert,
+		acceptRemoteConnections = false, sendSAPTargetCSP = false, cdnUrl}) {
+		// TODO provide proxy configuration name
 
+		const projectResourceCollections = resourceFactory.createCollectionsForTree(tree);
 
 		// TODO change to ReaderCollection once duplicates are sorted out
 		const combo = new ReaderCollectionPrioritized({
@@ -126,21 +138,24 @@ module.exports = {
 			tree,
 			resources,
 			options: {
-				sendSAPTargetCSP
+				sendSAPTargetCSP,
+				useProxy,
+				cdnUrl
 			}
 		});
 
 		let app = express();
 		await middlewareManager.applyMiddleware(app);
 
-		if (h2) {
-			app = _addSsl({app, key, cert});
+		if (h2 || useProxy) {
+			app = _addSsl({app, key, cert, h2});
 		}
 
 		const {port, server} = await _listen(app, requestedPort, changePortIfInUse, acceptRemoteConnections);
 
 		return {
-			h2,
+			h2: h2, // TODO 2.0: deprecate in favor of protocol
+			protocol: (h2 || useProxy) ? "https" : "http",
 			port,
 			close: function(callback) {
 				server.close(callback);

--- a/package-lock.json
+++ b/package-lock.json
@@ -636,6 +636,14 @@
 			"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
 			"dev": true
 		},
+		"agent-base": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"requires": {
+				"es6-promisify": "^5.0.0"
+			}
+		},
 		"ajv": {
 			"version": "6.10.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -2515,6 +2523,19 @@
 				"event-emitter": "~0.3.5"
 			}
 		},
+		"es6-promise": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+		},
+		"es6-promisify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"requires": {
+				"es6-promise": "^4.0.3"
+			}
+		},
 		"es6-set": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
@@ -3509,6 +3530,30 @@
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
 				"sshpk": "^1.7.0"
+			}
+		},
+		"https-proxy-agent": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+			"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+			"requires": {
+				"agent-base": "^4.1.0",
+				"debug": "^3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				}
 			}
 		},
 		"i": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -496,9 +496,8 @@
 			"integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
 		},
 		"@ui5/builder": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@ui5/builder/-/builder-1.4.0.tgz",
-			"integrity": "sha512-gc3AVyOMHKKnXcTf9F/QP3S2E5+4flmXmuFAoD9tqlFXAfBcc+9CNJiuLJzj1keaClsVk/ZkMjkloo7Dpx50WA==",
+			"version": "github:SAP/ui5-builder#5d09696db18028c28b109e690cd422314debb4e3",
+			"from": "github:SAP/ui5-builder#feature-proxy",
 			"requires": {
 				"@ui5/fs": "^1.1.2",
 				"@ui5/logger": "^1.0.1",
@@ -519,7 +518,7 @@
 				"rimraf": "^2.6.3",
 				"semver": "^6.3.0",
 				"slash": "^3.0.0",
-				"uglify-es": "^3.2.2",
+				"terser": "^4.1.3",
 				"xml2js": "^0.4.17",
 				"yazl": "^2.5.1"
 			},
@@ -1250,8 +1249,7 @@
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-			"dev": true
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
 		},
 		"bytes": {
 			"version": "3.0.0",
@@ -6221,7 +6219,6 @@
 			"version": "0.5.13",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
 			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -6720,6 +6717,23 @@
 				"execa": "^0.7.0"
 			}
 		},
+		"terser": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.1.3.tgz",
+			"integrity": "sha512-on13d+cnpn5bMouZu+J8tPYQecsdRJCJuxFJ+FVoPBoLJgk5bCBkp+Uen2hWyi0KIUm6eDarnlAlH+KgIx/PuQ==",
+			"requires": {
+				"commander": "^2.20.0",
+				"source-map": "~0.6.1",
+				"source-map-support": "~0.5.12"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+				}
+			}
+		},
 		"test-exclude": {
 			"version": "5.2.3",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
@@ -6853,9 +6867,9 @@
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
 		"type": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
-			"integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
+			"integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg=="
 		},
 		"type-check": {
 			"version": "0.3.2",
@@ -6900,22 +6914,6 @@
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
 			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
 			"dev": true
-		},
-		"uglify-es": {
-			"version": "3.3.9",
-			"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-			"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-			"requires": {
-				"commander": "~2.13.0",
-				"source-map": "~0.6.1"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.13.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
-				}
-			}
 		},
 		"uid2": {
 			"version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 		"url": "git@github.com:SAP/ui5-server.git"
 	},
 	"dependencies": {
-		"@ui5/builder": "^1.4.0",
+		"@ui5/builder": "SAP/ui5-builder#feature-proxy",
 		"@ui5/fs": "^1.1.2",
 		"@ui5/logger": "^1.0.1",
 		"compression": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,8 @@
 		"etag": "^1.8.1",
 		"express": "^4.17.1",
 		"fresh": "^0.5.2",
+		"http-proxy": "^1.17.0",
+		"https-proxy-agent": "^2.2.1",
 		"make-dir": "^3.0.0",
 		"mime-types": "^2.1.24",
 		"parseurl": "^1.3.3",


### PR DESCRIPTION
Work in progress. Possible implementation of a somewhat ABAP/NW Gateway focused "proxy mode" as part of the standard UI5 Tooling.

Related to https://github.com/SAP/ui5-tooling/pull/41

Note that many custom proxy implementations are already possible using [Custom UI5 Server Middleware](https://sap.github.io/ui5-tooling/pages/extensibility/CustomServerMiddleware/)

### Basic Working Principle
1. Normalize request URI
	- Examples:
        - `/sap/bc/ui5_ui5/sap/my_app/~D9F8F129E4F10B8324F1751A2A3C583A~5/Component.js` becomes  
`/Component.js`
	    - `/sap/bc/ui5_ui5/sap/my_lib/~D9F8F129E4F10B8324F1751A2A3C583A~5/library.js` becomes  
`/resources/my/lib/library.js`
2. Try to serve normalized URI from local projects
    - All projects listed when executing `ui5 tree` will be used
3. If root project defines `server.cdnUrl` configuration: Try to serve normalized URI from configured CDN
4. Try to serve **original** URI from configured proxy destination

### Possible Scenarios
1. Work on a locally cloned application and library in an ABAP hosted FLP environment
1. Launch an ABAP hosted FLP with a different UI5 version (from CDN or local)
1. ...

### Minimal Configuration
```yaml
specVersion: '1.1a'
metadata:
  name: my.app
type: application
---
specVersion: '1.1a'
kind: extension
type: proxy-configuration
metadata:
  name: abc-proxy
proxy:
  configuration:
    destination:
      origin: https://abc.acme.corp:44300
    insecure: true # obviously: do not send confidential data through the proxy when this is set to true
```

### Full Configuration
```yaml
specVersion: '1.1a'
metadata:
  name: my.app
type: application
server:
  cdnUrl: https://sapui5.hana.ondemand.com
---
specVersion: '1.1a'
kind: extension
type: proxy-configuration
metadata:
  name: abc-proxy
proxy:
  configuration:
    destination:
      origin: https://abc.acme.corp:44300
      ui5Root: /sap/bc/ui5_ui5/ui2/ushell # required when serving UI5 framework resources from local system or CDN
      ca: # not sure whether this already works, you'll have to use insecure if not
        - ./ca/MyCorpRoot.crt
    insecure: true
    appOnly: true # disables "ui5Root" configuration to enforce proxying UI5 framework resources from configured proxy destination
```

### How to try
In your projects package.json:
```json
  "devDependencies": {
    "@ui5/cli": "SAP/ui5-cli#feature-proxy"
  }
```

Refrain from using any lockfiles to ensure you always install the latest commits from the referenced feature branches:  
```sh
echo 'package-lock=false' >> .npmrc
```

Try it:  
```sh
ui5 serve --proxy # --verbose for details
```

### Notes
- All application or library projects that shall be served from local system should use specification version `1.1a`
- Applications need to define the `"sap.platform.abap".uri` attribute in their `manifest.json` (example value `/sap/bc/ui5_ui5/sap/my_app`)
- Libraries also need to define the `"sap.platform.abap".uri` attribute. As a fallback to the `manifest.json` this might be defined in `.library` at `library.appData.manifest."sap.platform.abap".uri` (example value `/sap/bc/ui5_ui5/sap/my_lib`)