### PR TITLE
[INTERNAL] sslUtil: Use "yesno" instead of "prompt" module

### DIFF
--- a/lib/sslUtil.js
+++ b/lib/sslUtil.js
@@ -10,8 +10,6 @@ const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 const makeDir = require("make-dir");
 
-const prompt = require("prompt");
-
 const sslUtil = {
 	/**
 	 * Creates a new SSL certificate or validates an existing one.
@@ -53,53 +51,42 @@ const sslUtil = {
 };
 
 
-function createAndInstallCertificate(keyPath, certPath) {
-	return new Promise(function(resolve, reject) {
-		prompt.start();
+async function createAndInstallCertificate(keyPath, certPath) {
+	const yesno = require("yesno");
 
-		const property = {
-			name: "yesno",
-			message: "No SSL certificates found. Do you want to create new SSL certificates and install them locally?",
-			validator: /y[es]*|n[o]?/,
-			warning: "Please respond yes or no",
-			default: "yes"
-		};
-
-		prompt.get(property, function(err, result) {
-			if (result.yesno !== "" && result.yesno !== "yes") {
-				reject(new Error("Certificate installation aborted! Please install the SSL certificate manually."));
-				return;
-			}
-			resolve();
-		});
-	}).then(function() {
-		// In case certificate is not found, create a self-signed one and put it into the user's trust store
-		const devCert = require("devcert-sanscache");
-
-		// Inform end user about entering his root password (needed for importing
-		// the created certificate into the system)
-		/* eslint-disable no-console */
-		// TODO: Prompt and logging should happen in CLI module rather than server
-		if (process.platform === "win32") {
-			console.log("Please press allow in the opened dialog to confirm importing the newly created " +
-				"SSL certificate into the operating system and browsers.");
-		} else {
-			console.log("Please enter your root password to allow importing the newly created " +
-				"SSL certificate into the operating system and browsers.");
-		}
-
-		return devCert("ui5-tooling").then(({key, cert}) => {
-			return Promise.all([
-				// Write certificates to the ui5 certificate folder
-				// such that they are used by default upon next startup
-				makeDir(path.dirname(keyPath)).then(() => writeFile(keyPath, key)),
-				makeDir(path.dirname(certPath)).then(() => writeFile(certPath, cert))
-			]).then(function() {
-				return {key, cert};
-			});
-		});
-		/* eslint-enable no-console */
+	const ok = await yesno({
+		question: "No SSL certificates found. Do you want to create new SSL certificates and install them locally? (yes)",
+		defaultValue: true
 	});
+
+	if (!ok) {
+		throw new Error("Certificate installation aborted! Please install the SSL certificate manually.");
+	}
+
+	// In case certificate is not found, create a self-signed one and put it into the user's trust store
+	const devCert = require("devcert-sanscache");
+
+	// Inform end user about entering his root password (needed for importing
+	// the created certificate into the system)
+	// TODO: Prompt and logging should happen in CLI module rather than server
+	if (process.platform === "win32") {
+		/* eslint-disable-next-line no-console */
+		console.log("Please press allow in the opened dialog to confirm importing the newly created " +
+			"SSL certificate into the operating system and browsers.");
+	} else {
+		/* eslint-disable-next-line no-console */
+		console.log("Please enter your root password to allow importing the newly created " +
+			"SSL certificate into the operating system and browsers.");
+	}
+
+	const {key, cert} = await devCert("ui5-tooling");
+	await Promise.all([
+		// Write certificates to the ui5 certificate folder
+		// such that they are used by default upon next startup
+		makeDir(path.dirname(keyPath)).then(() => writeFile(keyPath, key)),
+		makeDir(path.dirname(certPath)).then(() => writeFile(certPath, cert))
+	])
+	return {key, cert};
 }
 
 function fileExists(filePath) {

--- a/lib/sslUtil.js
+++ b/lib/sslUtil.js
@@ -55,7 +55,8 @@ async function createAndInstallCertificate(keyPath, certPath) {
 	const yesno = require("yesno");
 
 	const ok = await yesno({
-		question: "No SSL certificates found. Do you want to create new SSL certificates and install them locally? (yes)",
+		question: "No SSL certificates found. " +
+			"Do you want to create new SSL certificates and install them locally? (yes)",
 		defaultValue: true
 	});
 
@@ -85,7 +86,7 @@ async function createAndInstallCertificate(keyPath, certPath) {
 		// such that they are used by default upon next startup
 		makeDir(path.dirname(keyPath)).then(() => writeFile(keyPath, key)),
 		makeDir(path.dirname(certPath)).then(() => writeFile(certPath, cert))
-	])
+	]);
 	return {key, cert};
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1723,7 +1723,8 @@
 		"colors": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -2106,7 +2107,8 @@
 		"cycle": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+			"dev": true
 		},
 		"d": {
 			"version": "1.0.1",
@@ -2183,7 +2185,8 @@
 		"deep-equal": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
-			"integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
+			"integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
+			"dev": true
 		},
 		"deep-extend": {
 			"version": "0.6.0",
@@ -3002,7 +3005,8 @@
 		"eyes": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+			"dev": true
 		},
 		"fast-deep-equal": {
 			"version": "2.0.1",
@@ -3592,7 +3596,8 @@
 		"i": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
-			"integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0="
+			"integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
+			"dev": true
 		},
 		"iconv-lite": {
 			"version": "0.4.24",
@@ -4920,7 +4925,8 @@
 		"mute-stream": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+			"dev": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -4931,7 +4937,8 @@
 		"ncp": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
-			"integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY="
+			"integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
+			"dev": true
 		},
 		"negotiator": {
 			"version": "0.6.2",
@@ -5619,7 +5626,8 @@
 		"pkginfo": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
-			"integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
+			"integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
+			"dev": true
 		},
 		"plur": {
 			"version": "3.1.1",
@@ -5684,6 +5692,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
 			"integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
+			"dev": true,
 			"requires": {
 				"colors": "^1.1.2",
 				"pkginfo": "0.x.x",
@@ -5791,6 +5800,7 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
 			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+			"dev": true,
 			"requires": {
 				"mute-stream": "~0.0.4"
 			}
@@ -6092,7 +6102,8 @@
 		"revalidator": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
-			"integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs="
+			"integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
+			"dev": true
 		},
 		"rimraf": {
 			"version": "3.0.0",
@@ -6445,7 +6456,8 @@
 		"stack-trace": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+			"dev": true
 		},
 		"stack-utils": {
 			"version": "1.0.2",
@@ -7187,6 +7199,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
 			"integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
+			"dev": true,
 			"requires": {
 				"async": "~0.9.0",
 				"deep-equal": "~0.2.1",
@@ -7199,12 +7212,14 @@
 				"async": {
 					"version": "0.9.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-					"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+					"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+					"dev": true
 				},
 				"rimraf": {
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
 					}
@@ -7338,6 +7353,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
 			"integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
+			"dev": true,
 			"requires": {
 				"async": "~1.0.0",
 				"colors": "1.0.x",
@@ -7351,17 +7367,20 @@
 				"async": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-					"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+					"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+					"dev": true
 				},
 				"colors": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+					"dev": true
 				},
 				"pkginfo": {
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
-					"integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE="
+					"integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
+					"dev": true
 				}
 			}
 		},
@@ -7596,6 +7615,11 @@
 			"requires": {
 				"buffer-crc32": "~0.2.3"
 			}
+		},
+		"yesno": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/yesno/-/yesno-0.3.1.tgz",
+			"integrity": "sha512-7RbCXegyu6DykWPWU0YEtW8gFJH8KBL2d5l2fqB0XpkH0Y9rk59YSSWpzEv7yNJBGAouPc67h3kkq0CZkpBdFw=="
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -110,10 +110,10 @@
 		"mime-types": "^2.1.24",
 		"parseurl": "^1.3.3",
 		"portscanner": "^2.1.1",
-		"prompt": "^1.0.0",
 		"replacestream": "^4.0.3",
 		"spdy": "^3.4.7",
-		"treeify": "^1.0.1"
+		"treeify": "^1.0.1",
+		"yesno": "^0.3.1"
 	},
 	"devDependencies": {
 		"@ui5/project": "^1.1.0",


### PR DESCRIPTION
The "prompt" module comes with several dependencies and has features
which are not required here.
Therefore the "yesno" module is more suitable as it adresses exactly our
use case and has no further npm dependencies.

Closes: https://github.com/SAP/ui5-server/issues/37
