### PR TITLE
[INTERNAL] server: Expose serveIndex options

### DIFF
--- a/lib/middleware/MiddlewareManager.js
+++ b/lib/middleware/MiddlewareManager.js
@@ -1,4 +1,5 @@
 const middlewareRepository = require("./middlewareRepository");
+
 /**
  *
  *
@@ -138,7 +139,15 @@ class MiddlewareManager {
 		// Handle anything but read operations *before* the serveIndex middleware
 		//	as it will reject them with a 405 (Method not allowed) instead of 404 like our old tooling
 		await this.addMiddleware("nonReadRequests");
-		await this.addMiddleware("serveIndex");
+		await this.addMiddleware("serveIndex", {
+			wrapperCallback: (middleware) => {
+				return ({resources}) => middleware({
+					resources,
+					showHidden: this.options.showHidden,
+					showDetails: this.options.showDetails
+				});
+			}
+		});
 	}
 
 	async addCustomMiddleware() {
@@ -181,4 +190,5 @@ class MiddlewareManager {
 		}
 	}
 }
+
 module.exports = MiddlewareManager;

--- a/lib/middleware/serveIndex.js
+++ b/lib/middleware/serveIndex.js
@@ -93,7 +93,7 @@ function createResourceInfos(resources) {
  * @returns {Function} Returns a server middleware closure.
  */
 
-function createMiddleware({resources, showDetails, showHidden}) {
+function createMiddleware({resources, showDetails = true, showHidden = true}) {
 	return function(req, res, next) {
 		log.verbose("\n Listing index of " + req.path);
 		const glob = req.path + (req.path.endsWith("/") ? "*" : "/*");

--- a/lib/middleware/serveIndex.js
+++ b/lib/middleware/serveIndex.js
@@ -93,7 +93,7 @@ function createResourceInfos(resources) {
  * @returns {Function} Returns a server middleware closure.
  */
 
-function createMiddleware({resources, showDetails = true, showHidden = true}) {
+function createMiddleware({resources, showDetails, showHidden}) {
 	return function(req, res, next) {
 		log.verbose("\n Listing index of " + req.path);
 		const glob = req.path + (req.path.endsWith("/") ? "*" : "/*");

--- a/lib/middleware/serveIndex/serveIndex.js
+++ b/lib/middleware/serveIndex/serveIndex.js
@@ -374,7 +374,7 @@ const icons = {
 	".yaws": "page_white_code.png"
 };
 
-function handleReuqest({req, res, next, showHidden, showDetails, resourceInfos}) {
+function handleRequest({req, res, next, showHidden, showDetails, resourceInfos}) {
 	const hidden = showHidden; // display hidden files
 	const view = showDetails ? "details" : "tiles";
 
@@ -416,4 +416,4 @@ function handleReuqest({req, res, next, showHidden, showDetails, resourceInfos})
 	});
 }
 
-module.exports = handleReuqest;
+module.exports = handleRequest;

--- a/lib/server.js
+++ b/lib/server.js
@@ -99,6 +99,8 @@ module.exports = {
 	 * @param {boolean} [options.sendSAPTargetCSP=false] If true, then the content security policies that SAP and UI5
 	 * 													aim for (AKA 'target policies'), are send for any requested
 	 * 													<code>*.html</code> file
+	 * @param {boolean} [options.showHidden=true] Show hidden files in the server directory listing
+	 * @param {boolean} [options.showDetails=true] Show a detailed table view in the server directory listing
 	 * @returns {Promise<object>} Promise resolving once the server is listening.
 	 * 							It resolves with an object containing the <code>port</code>,
 	 * 							<code>h2</code>-flag and a <code>close</code> function,

--- a/lib/server.js
+++ b/lib/server.js
@@ -106,7 +106,8 @@ module.exports = {
 	 */
 	async serve(tree, {
 		port: requestedPort, changePortIfInUse = false, h2 = false, key, cert,
-		acceptRemoteConnections = false, sendSAPTargetCSP = false}) {
+		acceptRemoteConnections = false, sendSAPTargetCSP = false, showHidden = false, showDetails = false
+	}) {
 		const projectResourceCollections = resourceFactory.createCollectionsForTree(tree);
 
 
@@ -126,7 +127,9 @@ module.exports = {
 			tree,
 			resources,
 			options: {
-				sendSAPTargetCSP
+				sendSAPTargetCSP,
+				showHidden,
+				showDetails
 			}
 		});
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -106,7 +106,7 @@ module.exports = {
 	 */
 	async serve(tree, {
 		port: requestedPort, changePortIfInUse = false, h2 = false, key, cert,
-		acceptRemoteConnections = false, sendSAPTargetCSP = false, showHidden = false, showDetails = false
+		acceptRemoteConnections = false, sendSAPTargetCSP = false, showHidden = true, showDetails = true
 	}) {
 		const projectResourceCollections = resourceFactory.createCollectionsForTree(tree);
 

--- a/test/lib/server/main.js
+++ b/test/lib/server/main.js
@@ -507,19 +507,19 @@ test("Get index of resources", (t) => {
 			t.deepEqual(res.statusCode, 200, "Correct HTTP status code");
 			t.is(res.headers["content-type"], "text/html; charset=utf-8", "Correct content type");
 			t.is(/<title>(.*)<\/title>/i.exec(res.text)[1], "Index of /", "Found correct title");
-			t.deepEqual(res.text.match(/<li/g).length, 7, "Found correct amount of <li> elements");
+			t.deepEqual(res.text.match(/<li/g).length, 8, "Found correct amount of <li> elements");
 		}),
 		request.get("/resources").then((res) => {
 			t.deepEqual(res.statusCode, 200, "Correct HTTP status code");
 			t.is(res.headers["content-type"], "text/html; charset=utf-8", "Correct content type");
 			t.is(/<title>(.*)<\/title>/i.exec(res.text)[1], "Index of /resources", "Found correct title");
-			t.deepEqual(res.text.match(/<li/g).length, 1, "Found correct amount of <li> elements");
+			t.deepEqual(res.text.match(/<li/g).length, 2, "Found correct amount of <li> elements");
 		}),
 		request.get("/resources/").then((res) => {
 			t.deepEqual(res.statusCode, 200, "Correct HTTP status code");
 			t.is(res.headers["content-type"], "text/html; charset=utf-8", "Correct content type");
 			t.is(/<title>(.*)<\/title>/i.exec(res.text)[1], "Index of /resources/", "Found correct title");
-			t.deepEqual(res.text.match(/<li/g).length, 1, "Found correct amount of <li> elements");
+			t.deepEqual(res.text.match(/<li/g).length, 2, "Found correct amount of <li> elements");
 		}),
 		request.get("/not-existing-folder").then((res) => {
 			t.deepEqual(res.statusCode, 404, "Correct HTTP status code");

--- a/test/lib/server/main.js
+++ b/test/lib/server/main.js
@@ -412,7 +412,8 @@ test("CSP (sap policies)", (t) => {
 	}).then((tree) => {
 		return server.serve(tree, {
 			port,
-			sendSAPTargetCSP: true
+			sendSAPTargetCSP: true,
+			showDetails: true
 		});
 	}).then((serveResult) => {
 		localServeResult = serveResult;
@@ -506,19 +507,19 @@ test("Get index of resources", (t) => {
 			t.deepEqual(res.statusCode, 200, "Correct HTTP status code");
 			t.is(res.headers["content-type"], "text/html; charset=utf-8", "Correct content type");
 			t.is(/<title>(.*)<\/title>/i.exec(res.text)[1], "Index of /", "Found correct title");
-			t.deepEqual(res.text.match(/<li/g).length, 8, "Found correct amount of <li> elements");
+			t.deepEqual(res.text.match(/<li/g).length, 7, "Found correct amount of <li> elements");
 		}),
 		request.get("/resources").then((res) => {
 			t.deepEqual(res.statusCode, 200, "Correct HTTP status code");
 			t.is(res.headers["content-type"], "text/html; charset=utf-8", "Correct content type");
 			t.is(/<title>(.*)<\/title>/i.exec(res.text)[1], "Index of /resources", "Found correct title");
-			t.deepEqual(res.text.match(/<li/g).length, 2, "Found correct amount of <li> elements");
+			t.deepEqual(res.text.match(/<li/g).length, 1, "Found correct amount of <li> elements");
 		}),
 		request.get("/resources/").then((res) => {
 			t.deepEqual(res.statusCode, 200, "Correct HTTP status code");
 			t.is(res.headers["content-type"], "text/html; charset=utf-8", "Correct content type");
 			t.is(/<title>(.*)<\/title>/i.exec(res.text)[1], "Index of /resources/", "Found correct title");
-			t.deepEqual(res.text.match(/<li/g).length, 2, "Found correct amount of <li> elements");
+			t.deepEqual(res.text.match(/<li/g).length, 1, "Found correct amount of <li> elements");
 		}),
 		request.get("/not-existing-folder").then((res) => {
 			t.deepEqual(res.statusCode, 404, "Correct HTTP status code");

--- a/test/lib/server/middleware/serveIndex.js
+++ b/test/lib/server/middleware/serveIndex.js
@@ -1,8 +1,8 @@
 const test = require("ava");
 const resourceFactory = require("@ui5/fs").resourceFactory;
 
-test.serial("Check if index for files is created", (t) => {
-	t.plan(3);
+test.serial("serveIndex default", (t) => {
+	t.plan(4);
 	const serveIndexMiddleware = require("../../../../lib/middleware/serveIndex");
 	const writeResource = function(writer, path, size = 0, stringContent = "abc") {
 		const resource = resourceFactory.createResource({path, string: stringContent});
@@ -24,6 +24,61 @@ test.serial("Check if index for files is created", (t) => {
 		writeResource(readerWriter, "/myFile1.meh", 1024), // KB
 		writeResource(readerWriter, "/myFile2.js", 1024 * 1024), // MB
 		writeResource(readerWriter, "/myFile3.properties", 1024 * 1024 * 1024), // GB
+		writeResource(readerWriter, "/.myFile4", 1024), // hidden 1 KB
+	]).then(() => {
+		const middleware = serveIndexMiddleware({
+			resources: {
+				all: readerWriter
+			}
+		});
+
+		return new Promise((resolve, reject) => {
+			const req = {
+				path: "/"
+			};
+			const res = {
+				writeHead: function(status, contentType) {
+				},
+				end: function(content) {
+					t.regex(content, RegExp("<li><a href=\"/myFile1.meh\" class=\"icon icon icon-meh icon-default\" title=\"myFile1.meh\"><span class=\"name\">myFile1.meh</span><span class=\"size\">1.00 KB</span>"));
+					t.regex(content, RegExp("<li><a href=\"/myFile2.js\" class=\"icon icon icon-js icon-application-javascript\" title=\"myFile2.js\"><span class=\"name\">myFile2.js</span><span class=\"size\">1.00 MB</span>"));
+					t.regex(content, RegExp("<li><a href=\"/myFile3.properties\" class=\"icon icon icon-properties icon-default\" title=\"myFile3.properties\"><span class=\"name\">myFile3.properties</span><span class=\"size\">1.00 GB</span>"));
+					t.regex(content, RegExp("<li><a href=\"/.myFile4\" class=\"icon icon icon- icon-default\" title=\".myFile4\"><span class=\"name\">.myFile4</span><span class=\"size\">1.00 KB</span>"));
+					resolve();
+				},
+			};
+			const next = function(err) {
+				reject(new Error(`Next callback called with error: ${err.message}`));
+			};
+			middleware(req, res, next);
+		});
+	});
+});
+
+test.serial("serveIndex no hidden", (t) => {
+	t.plan(4);
+	const serveIndexMiddleware = require("../../../../lib/middleware/serveIndex");
+	const writeResource = function(writer, path, size = 0, stringContent = "abc") {
+		const resource = resourceFactory.createResource({path, string: stringContent});
+		resource.getStatInfo = function() {
+			return {
+				mtime: 0,
+				size: size,
+				isDirectory: function() {
+					return false;
+				}
+			};
+		};
+		return writer.write(resource);
+	};
+
+	const readerWriter = resourceFactory.createAdapter({virBasePath: "/"});
+
+	return Promise.all([
+		writeResource(readerWriter, "/myFile1.meh", 1024), // KB
+		writeResource(readerWriter, "/myFile2.js", 1024 * 1024), // MB
+		writeResource(readerWriter, "/myFile3.properties", 1024 * 1024 * 1024), // GB
+		writeResource(readerWriter, "/.myFile4", 1024), // hidden 1 KB
 	]).then(() => {
 		const middleware = serveIndexMiddleware({
 			resources: {
@@ -44,6 +99,63 @@ test.serial("Check if index for files is created", (t) => {
 					t.regex(content, RegExp("<li><a href=\"/myFile1.meh\" class=\"icon icon icon-meh icon-default\" title=\"myFile1.meh\"><span class=\"name\">myFile1.meh</span><span class=\"size\">1.00 KB</span>"));
 					t.regex(content, RegExp("<li><a href=\"/myFile2.js\" class=\"icon icon icon-js icon-application-javascript\" title=\"myFile2.js\"><span class=\"name\">myFile2.js</span><span class=\"size\">1.00 MB</span>"));
 					t.regex(content, RegExp("<li><a href=\"/myFile3.properties\" class=\"icon icon icon-properties icon-default\" title=\"myFile3.properties\"><span class=\"name\">myFile3.properties</span><span class=\"size\">1.00 GB</span>"));
+					t.notRegex(content, RegExp("<li><a href=\"/.myFile4\" class=\"icon icon icon- icon-default\" title=\".myFile4\"><span class=\"name\">.myFile4</span><span class=\"size\">1.00 KB</span>"));
+					resolve();
+				},
+			};
+			const next = function(err) {
+				reject(new Error(`Next callback called with error: ${err.message}`));
+			};
+			middleware(req, res, next);
+		});
+	});
+});
+
+test.serial("serveIndex no details", (t) => {
+	t.plan(4);
+	const serveIndexMiddleware = require("../../../../lib/middleware/serveIndex");
+	const writeResource = function(writer, path, size = 0, stringContent = "abc") {
+		const resource = resourceFactory.createResource({path, string: stringContent});
+		resource.getStatInfo = function() {
+			return {
+				mtime: 0,
+				size: size,
+				isDirectory: function() {
+					return false;
+				}
+			};
+		};
+		return writer.write(resource);
+	};
+
+	const readerWriter = resourceFactory.createAdapter({virBasePath: "/"});
+
+	return Promise.all([
+		writeResource(readerWriter, "/myFile1.meh", 1024), // KB
+		writeResource(readerWriter, "/myFile2.js", 1024 * 1024), // MB
+		writeResource(readerWriter, "/myFile3.properties", 1024 * 1024 * 1024), // GB
+		writeResource(readerWriter, "/.myFile4", 1024), // hidden 1 KB
+	]).then(() => {
+		const middleware = serveIndexMiddleware({
+			resources: {
+				all: readerWriter
+			},
+			showDetails: false,
+			showHidden: true
+		});
+
+		return new Promise((resolve, reject) => {
+			const req = {
+				path: "/"
+			};
+			const res = {
+				writeHead: function(status, contentType) {
+				},
+				end: function(content) {
+					t.regex(content, RegExp("<li><a href=\"/myFile1.meh\" class=\"icon icon icon-meh icon-default\" title=\"myFile1.meh\"><span class=\"name\">myFile1.meh</span><span class=\"size\">1.00 KB</span>"));
+					t.regex(content, RegExp("<li><a href=\"/myFile2.js\" class=\"icon icon icon-js icon-application-javascript\" title=\"myFile2.js\"><span class=\"name\">myFile2.js</span><span class=\"size\">1.00 MB</span>"));
+					t.regex(content, RegExp("<li><a href=\"/myFile3.properties\" class=\"icon icon icon-properties icon-default\" title=\"myFile3.properties\"><span class=\"name\">myFile3.properties</span><span class=\"size\">1.00 GB</span>"));
+					t.regex(content, RegExp("<li><a href=\"/.myFile4\" class=\"icon icon icon- icon-default\" title=\".myFile4\"><span class=\"name\">.myFile4</span><span class=\"size\">1.00 KB</span>"));
 					resolve();
 				},
 			};

--- a/test/lib/server/middleware/serveIndex.js
+++ b/test/lib/server/middleware/serveIndex.js
@@ -28,7 +28,9 @@ test.serial("Check if index for files is created", (t) => {
 		const middleware = serveIndexMiddleware({
 			resources: {
 				all: readerWriter
-			}
+			},
+			showDetails: true,
+			showHidden: false
 		});
 
 		return new Promise((resolve, reject) => {


### PR DESCRIPTION
In the last PR (#253) i forgot to expose the cli-arguments to the serveIndex Middleware.
Here is the solution ...

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [x] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
