### PR TITLE
[FIX] sslUtils: Fix Invalid Common Name error

### DIFF
--- a/lib/sslUtil.js
+++ b/lib/sslUtil.js
@@ -80,7 +80,7 @@ async function createAndInstallCertificate(keyPath, certPath) {
 			"SSL certificate into the operating system and browsers.");
 	}
 
-	const {key, cert} = await devCert("ui5-tooling");
+	const {key, cert} = await devCert("UI5Tooling");
 	await Promise.all([
 		// Write certificates to the ui5 certificate folder
 		// such that they are used by default upon next startup

--- a/package-lock.json
+++ b/package-lock.json
@@ -2299,9 +2299,9 @@
 			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
 		},
 		"devcert-sanscache": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/devcert-sanscache/-/devcert-sanscache-0.4.7.tgz",
-			"integrity": "sha512-mrCZDM/WayeLIRErtbRGjEkb1chxe9Vg0Cwv88oUJiEmt6Ts8VWLe6G0WM9PbMlW0tVeYAOc0KBlIrm5KUkYHw==",
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/devcert-sanscache/-/devcert-sanscache-0.4.6.tgz",
+			"integrity": "sha512-Itp0Y58HtMqZ1v8YHYmtXpSFN5l4NaBcy7vBQUFxy2hs/HpNVTrNEynF9E2N9SK0uqa0vn7LFL8Rwinm500Uag==",
 			"requires": {
 				"command-exists": "^1.2.2",
 				"get-port": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
 		"compression": "^1.7.4",
 		"connect-openui5": "^0.9.0",
 		"cors": "^2.8.5",
-		"devcert-sanscache": "^0.4.7",
+		"devcert-sanscache": "0.4.6",
 		"escape-html": "^1.0.3",
 		"etag": "^1.8.1",
 		"express": "^4.17.1",

--- a/test/lib/server/sslUtil.js
+++ b/test/lib/server/sslUtil.js
@@ -45,7 +45,7 @@ test.serial("Create new certificate and install it", (t) => {
 	});
 
 	mock("devcert-sanscache", function(name) {
-		t.deepEqual(name, "ui5-tooling", "Create certificate for ui5-tooling.");
+		t.deepEqual(name, "UI5Tooling", "Create certificate for UI5Tooling.");
 		return Promise.resolve({
 			key: sslKey,
 			cert: sslCert
@@ -119,7 +119,7 @@ test.serial("Create new certificate not succeeded", async (t) => {
 	});
 
 	mock("devcert-sanscache", function(name) {
-		t.deepEqual(name, "ui5-tooling", "Create certificate for ui5-tooling.");
+		t.deepEqual(name, "UI5Tooling", "Create certificate for UI5Tooling.");
 		return Promise.resolve({
 			key: "aaa",
 			cert: "bbb"


### PR DESCRIPTION
Caused by (incorrect) regex introduced in
https://github.com/guybedford/devcert/commit/571f4e6d077f7f21c6aed655ae380d85a7a5d3b8
and released as patch.

Resolved by pin devcert-sanscache dependency to last working version
0.4.6