### PR TITLE
[FIX] serveIndex: Add missing dependency to "graceful-fs"

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
 		"etag": "^1.8.1",
 		"express": "^4.17.1",
 		"fresh": "^0.5.2",
+		"graceful-fs": "^4.2.3",
 		"make-dir": "^3.0.0",
 		"mime-types": "^2.1.26",
 		"parseurl": "^1.3.3",


### PR DESCRIPTION
**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [ ] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
