### PR TITLE
[FIX] versionInfo: Fix pattern to glob for .library files

### DIFF
--- a/lib/middleware/versionInfo.js
+++ b/lib/middleware/versionInfo.js
@@ -11,7 +11,7 @@ const createVersionInfoProcessor = require("@ui5/builder").processors.versionInf
  */
 function createMiddleware({resources, tree: project}) {
 	return function versionInfo(req, res, next) {
-		resources.dependencies.byGlob("/**/.library")
+		resources.dependencies.byGlob("/resources/**/.library")
 			.then((resources) => {
 				resources.sort((a, b) => {
 					return a._project.metadata.name.localeCompare(b._project.metadata.name);


### PR DESCRIPTION
To generate the VersionInfo, the used glob pattern should only match .library files within the resource folder. Otherwise it is possible to find additional .library files, e.g. from unit tests.