### PR TITLE
[BREAKING] serveResources middleware: Expect *.properties files in UTF-8 by default

### DIFF
--- a/lib/middleware/serveResources.js
+++ b/lib/middleware/serveResources.js
@@ -41,9 +41,19 @@ function createMiddleware({resources, middlewareUtil}) {
 				// Special handling for *.properties files escape non ascii characters.
 				const nonAsciiEscaper = require("@ui5/builder").processors.nonAsciiEscaper;
 				const project = resource._project; // _project might not be defined
-				const propertiesFileSourceEncoding = project && project.resources &&
+				let propertiesFileSourceEncoding = project && project.resources &&
 					project.resources.configuration && project.resources.configuration.propertiesFileSourceEncoding;
-				const encoding = nonAsciiEscaper.getEncodingFromAlias(propertiesFileSourceEncoding || "ISO-8859-1");
+
+				if (!propertiesFileSourceEncoding) {
+					if (project && ["0.1", "1.0", "1.1"].includes(project.specVersion)) {
+						// default encoding to "ISO-8859-1" for old specVersions
+						propertiesFileSourceEncoding = "ISO-8859-1";
+					} else {
+						// default encoding to "UTF-8" for all projects starting with specVersion 2.0
+						propertiesFileSourceEncoding = "UTF-8";
+					}
+				}
+				const encoding = nonAsciiEscaper.getEncodingFromAlias(propertiesFileSourceEncoding);
 				await nonAsciiEscaper({
 					resources: [resource], options: {
 						encoding


### PR DESCRIPTION
Also fix some tests that expected different unicode escape sequences
for the same input. The used input encoding did not match the specified
propertiesFileSourceEncoding.

BREAKING CHANGE:
If the project a "*.properties" resource originates from cannot be
determined, or if the project does not define a
propertiesFileSourceEncoding configuration or uses a legacy specVersion
(<2.0), the serveResources middleware assumes that the resource is UTF-8
encoded instead of ISO-8859-1.