### PR TITLE
Server: If port is taken, include "EADDRINUSE" in error message

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -41,10 +41,21 @@ function _listen(app, port, changePortIfInUse, acceptRemoteConnections) {
 
 			if (!foundPort) {
 				if (changePortIfInUse) {
-					reject(new Error(`Could not find available ports between ${port} and ${portMax}.`));
+					const error = new Error(
+						`EADDRINUSE: Could not find available ports between ${port} and ${portMax}.`);
+					error.code = "EADDRINUSE";
+					error.errno = "EADDRINUSE";
+					error.address = host;
+					error.port = portMax;
+					reject(error);
 					return;
 				} else {
-					reject(new Error(`Port ${port} already in use.`));
+					const error = new Error(`EADDRINUSE: Port ${port} is already in use.`);
+					error.code = "EADDRINUSE";
+					error.errno = "EADDRINUSE";
+					error.address = host;
+					error.port = portMax;
+					reject(error);
 					return;
 				}
 			}

--- a/test/lib/server/ports.js
+++ b/test/lib/server/ports.js
@@ -35,7 +35,7 @@ test.after(() => {
 });
 
 test("Start server - Port is already taken and an error occurs", async (t) => {
-	t.plan(2);
+	t.plan(6);
 	const port = 3360;
 	const nodeServer = http.createServer((req, res) => {
 		res.end();
@@ -59,7 +59,28 @@ test("Start server - Port is already taken and an error occurs", async (t) => {
 	return t.throwsAsync(startServer).then((error) => {
 		t.deepEqual(
 			error.message,
-			"Port 3360 already in use.", "Server could not start, port is already taken and no other port is used."
+			"EADDRINUSE: Port 3360 is already in use.",
+			"Correct error message"
+		);
+		t.deepEqual(
+			error.code,
+			"EADDRINUSE",
+			"Correct error code"
+		);
+		t.deepEqual(
+			error.errno,
+			"EADDRINUSE",
+			"Correct error number"
+		);
+		t.deepEqual(
+			error.address,
+			"localhost",
+			"Correct error address"
+		);
+		t.deepEqual(
+			error.port,
+			3360,
+			"Correct error port"
 		);
 	});
 });
@@ -127,7 +148,7 @@ test.serial("Start server - Port can not be determined and an error occurs", (t)
 
 
 test("Start server - Port is already taken and an error occurs because no other port can be determined", (t) => {
-	t.plan(2);
+	t.plan(6);
 	const portStart = 4000;
 	const portRange = 31;
 	const servers = [];
@@ -164,8 +185,28 @@ test("Start server - Port is already taken and an error occurs because no other 
 		}
 		t.deepEqual(
 			error.message,
-			"Could not find available ports between 4000 and 4030.",
+			"EADDRINUSE: Could not find available ports between 4000 and 4030.",
 			"Server could not start, port is already taken and no other port is used."
+		);
+		t.deepEqual(
+			error.code,
+			"EADDRINUSE",
+			"Correct error code"
+		);
+		t.deepEqual(
+			error.errno,
+			"EADDRINUSE",
+			"Correct error number"
+		);
+		t.deepEqual(
+			error.address,
+			"localhost",
+			"Correct error address"
+		);
+		t.deepEqual(
+			error.port,
+			4030,
+			"Correct error port"
 		);
 	});
 });


### PR DESCRIPTION
This makes it easier for consuming tools to programatically identify
this error.

See also https://nodejs.org/api/errors.html#errors_common_system_errors