### PR TITLE
[FIX] CSP Middleware: Use native res.getHeader/setHeader methods

### DIFF
--- a/lib/middleware/csp.js
+++ b/lib/middleware/csp.js
@@ -6,13 +6,13 @@ const HEADER_CONTENT_SECURITY_POLICY_REPORT_ONLY = "Content-Security-Policy-Repo
 const rPolicy = /^([-_a-zA-Z0-9]+)(:report-only|:ro)?$/i;
 
 function addHeader(res, header, value) {
-	const current = res.get(header);
+	const current = res.getHeader(header);
 	if ( current == null ) {
-		res.set(header, value);
+		res.setHeader(header, value);
 	} else if ( Array.isArray(current) ) {
-		res.set(header, [...current, value]);
+		res.setHeader(header, [...current, value]);
 	} else {
-		res.set(header, [current, value]);
+		res.setHeader(header, [current, value]);
 	}
 }
 

--- a/test/lib/server/middleware/csp.js
+++ b/test/lib/server/middleware/csp.js
@@ -5,10 +5,10 @@ test("Default Settings", (t) => {
 	t.plan(3 + 7); // fourth request should end in middleware and not call next!
 	const middleware = cspMiddleware("sap-ui-xx-csp-policy", {});
 	const res = {
-		get: function() {
+		getHeader: function() {
 			return undefined;
 		},
-		set: function(header, value) {
+		setHeader: function(header, value) {
 			t.fail(`should not be called with header ${header} and value ${value}`);
 		}
 	};
@@ -54,10 +54,10 @@ test("Custom Settings", (t) => {
 	});
 	let expected;
 	const res = {
-		get: function() {
+		getHeader: function() {
 			return undefined;
 		},
-		set: function(header, value) {
+		setHeader: function(header, value) {
 			if ( header.toLowerCase() === "content-security-policy" ) {
 				t.is(value, expected.shift(), "should have the expected value");
 			} else {
@@ -92,10 +92,10 @@ test("No Dynamic Policy Definition", (t) => {
 		allowDynamicPolicyDefinition: false
 	});
 	const res = {
-		get: function() {
+		getHeader: function() {
 			return undefined;
 		},
-		set: function(header, value) {
+		setHeader: function(header, value) {
 			if ( header.toLowerCase() === "content-security-policy" ) {
 				t.is(value, expected.shift(), "should have the expected value");
 			} else {
@@ -124,10 +124,10 @@ test("Header Manipulation", (t) => {
 	});
 	let cspHeader = "default-src: spdy:";
 	const res = {
-		get: function() {
+		getHeader: function() {
 			return cspHeader;
 		},
-		set: function(header, value) {
+		setHeader: function(header, value) {
 			if ( header.toLowerCase() === "content-security-policy" ) {
 				cspHeader = value;
 			} else {


### PR DESCRIPTION
Using getHeader/setHeader instead of the express methods get/set to
allow using the middleware with a different server framework or as a
native Node.js server handler.

This also aligns the code with the other middleware which already use
getHeader/setHeader.