### PR TITLE
[INTERNAL] serve tests fix: fs Resource#clone change

### DIFF
--- a/test/lib/server/middleware/serveIndex.js
+++ b/test/lib/server/middleware/serveIndex.js
@@ -2,32 +2,18 @@ const test = require("ava");
 const resourceFactory = require("@ui5/fs").resourceFactory;
 const MiddlewareUtil = require("../../../../lib/middleware/MiddlewareUtil");
 
-const modifyClone = (resource, fnModifyClone) => {
-	const origClone = resource.clone;
-	resource.clone = function(...args) {
-		return origClone.apply(resource, args).then((clonedResource) => {
-			fnModifyClone(clonedResource);
-			return clonedResource;
-		});
-	};
-};
-
 test.serial("serveIndex default", (t) => {
 	t.plan(4);
 	const serveIndexMiddleware = require("../../../../lib/middleware/serveIndex");
 	const writeResource = function(writer, path, size = 0, stringContent = "abc") {
-		const resource = resourceFactory.createResource({path, string: stringContent});
-		modifyClone(resource, (clonedResource) => {
-			clonedResource.getStatInfo = function() {
-				return {
-					mtime: 0,
-					size: size,
-					isDirectory: function() {
-						return false;
-					}
-				};
-			};
-		});
+		const statInfo = {
+			mtime: 0,
+			size: size,
+			isDirectory: function() {
+				return false;
+			}
+		};
+		const resource = resourceFactory.createResource({statInfo, path, string: stringContent});
 		return writer.write(resource);
 	};
 
@@ -73,18 +59,14 @@ test.serial("serveIndex no hidden", (t) => {
 	t.plan(4);
 	const serveIndexMiddleware = require("../../../../lib/middleware/serveIndex");
 	const writeResource = function(writer, path, size = 0, stringContent = "abc") {
-		const resource = resourceFactory.createResource({path, string: stringContent});
-		modifyClone(resource, (clonedResource) => {
-			clonedResource.getStatInfo = function() {
-				return {
-					mtime: 0,
-					size: size,
-					isDirectory: function() {
-						return false;
-					}
-				};
-			};
-		});
+		const statInfo = {
+			mtime: 0,
+			size: size,
+			isDirectory: function() {
+				return false;
+			}
+		};
+		const resource = resourceFactory.createResource({statInfo, path, string: stringContent});
 		return writer.write(resource);
 	};
 
@@ -132,18 +114,14 @@ test.serial("serveIndex no details", (t) => {
 	t.plan(4);
 	const serveIndexMiddleware = require("../../../../lib/middleware/serveIndex");
 	const writeResource = function(writer, path, size = 0, stringContent = "abc") {
-		const resource = resourceFactory.createResource({path, string: stringContent});
-		modifyClone(resource, (clonedResource) => {
-			clonedResource.getStatInfo = function() {
-				return {
-					mtime: 0,
-					size: size,
-					isDirectory: function() {
-						return false;
-					}
-				};
-			};
-		});
+		const statInfo = {
+			mtime: 0,
+			size: size,
+			isDirectory: function() {
+				return false;
+			}
+		};
+		const resource = resourceFactory.createResource({statInfo, path, string: stringContent});
 		return writer.write(resource);
 	};
 

--- a/test/lib/server/middleware/serveIndex.js
+++ b/test/lib/server/middleware/serveIndex.js
@@ -2,20 +2,32 @@ const test = require("ava");
 const resourceFactory = require("@ui5/fs").resourceFactory;
 const MiddlewareUtil = require("../../../../lib/middleware/MiddlewareUtil");
 
+const modifyClone = (resource, fnModifyClone) => {
+	const origClone = resource.clone;
+	resource.clone = function(...args) {
+		return origClone.apply(resource, args).then((clonedResource) => {
+			fnModifyClone(clonedResource);
+			return clonedResource;
+		});
+	};
+};
+
 test.serial("serveIndex default", (t) => {
 	t.plan(4);
 	const serveIndexMiddleware = require("../../../../lib/middleware/serveIndex");
 	const writeResource = function(writer, path, size = 0, stringContent = "abc") {
 		const resource = resourceFactory.createResource({path, string: stringContent});
-		resource.getStatInfo = function() {
-			return {
-				mtime: 0,
-				size: size,
-				isDirectory: function() {
-					return false;
-				}
+		modifyClone(resource, (clonedResource) => {
+			clonedResource.getStatInfo = function() {
+				return {
+					mtime: 0,
+					size: size,
+					isDirectory: function() {
+						return false;
+					}
+				};
 			};
-		};
+		});
 		return writer.write(resource);
 	};
 
@@ -62,15 +74,17 @@ test.serial("serveIndex no hidden", (t) => {
 	const serveIndexMiddleware = require("../../../../lib/middleware/serveIndex");
 	const writeResource = function(writer, path, size = 0, stringContent = "abc") {
 		const resource = resourceFactory.createResource({path, string: stringContent});
-		resource.getStatInfo = function() {
-			return {
-				mtime: 0,
-				size: size,
-				isDirectory: function() {
-					return false;
-				}
+		modifyClone(resource, (clonedResource) => {
+			clonedResource.getStatInfo = function() {
+				return {
+					mtime: 0,
+					size: size,
+					isDirectory: function() {
+						return false;
+					}
+				};
 			};
-		};
+		});
 		return writer.write(resource);
 	};
 
@@ -119,15 +133,17 @@ test.serial("serveIndex no details", (t) => {
 	const serveIndexMiddleware = require("../../../../lib/middleware/serveIndex");
 	const writeResource = function(writer, path, size = 0, stringContent = "abc") {
 		const resource = resourceFactory.createResource({path, string: stringContent});
-		resource.getStatInfo = function() {
-			return {
-				mtime: 0,
-				size: size,
-				isDirectory: function() {
-					return false;
-				}
+		modifyClone(resource, (clonedResource) => {
+			clonedResource.getStatInfo = function() {
+				return {
+					mtime: 0,
+					size: size,
+					isDirectory: function() {
+						return false;
+					}
+				};
 			};
-		};
+		});
 		return writer.write(resource);
 	};
 

--- a/test/lib/server/middleware/serveResources.js
+++ b/test/lib/server/middleware/serveResources.js
@@ -4,6 +4,17 @@ const {Readable, Writable} = require("stream");
 const resourceFactory = require("@ui5/fs").resourceFactory;
 const serveResourcesMiddleware = require("../../../../lib/middleware/serveResources");
 const MiddlewareUtil = require("../../../../lib/middleware/MiddlewareUtil");
+
+const modifyClone = (resource, fnModifyClone) => {
+	const origClone = resource.clone;
+	resource.clone = function(...args) {
+		return origClone.apply(resource, args).then((clonedResource) => {
+			fnModifyClone(clonedResource);
+			return clonedResource;
+		});
+	};
+};
+
 const writeResource = function(writer, path, size, stringContent, stringEncoding, project) {
 	const statInfo = {
 		ino: 0,
@@ -20,12 +31,15 @@ const writeResource = function(writer, path, size, stringContent, stringEncoding
 		statInfo,
 		project
 	});
-	// stub resource functionality in order to be able to get the Resource's content. Otherwise it would be drained.
-	sinon.stub(resource, "getStream").returns({
-		pipe: function() {
-		}
-	});
+
 	return writer.write(resource).then(() => {
+		modifyClone(resource, (clonedResource) => {
+			// stub resource functionality in order to be able to get the Resource's content. Otherwise it would be drained.
+			sinon.stub(clonedResource, "getStream").returns({
+				pipe: function() {
+				}
+			});
+		});
 		return resource;
 	});
 };
@@ -38,6 +52,7 @@ const fakeResponse = {
 test.afterEach.always((t) => {
 	sinon.restore();
 });
+
 
 test.serial("Check if properties file is served properly", (t) => {
 	t.plan(4);
@@ -53,7 +68,12 @@ test.serial("Check if properties file is served properly", (t) => {
 
 	return writeResource(readerWriter, "/myFile3.properties", 1024 * 1024, "key=titel\nfame=straße", "latin1", project)
 		.then((resource) => {
-			const setStringSpy = sinon.spy(resource, "setString");
+			let setStringSpy;
+			let clonedResource;
+			modifyClone(resource, (clonedResourceInternal) => {
+				setStringSpy = sinon.spy(clonedResourceInternal, "setString");
+				clonedResource = clonedResourceInternal;
+			});
 			const middleware = serveResourcesMiddleware({
 				middlewareUtil: new MiddlewareUtil(),
 				resources: {
@@ -72,7 +92,7 @@ test.serial("Check if properties file is served properly", (t) => {
 				throw new Error(`Next callback called with error: ${err.message}`);
 			};
 			return middleware(req, response, next).then((o) => {
-				return resource.getString();
+				return clonedResource.getString();
 			}).then((content) => {
 				t.is(content, `key=titel
 fame=stra\\u00dfe`);
@@ -97,7 +117,12 @@ test.serial("Check if properties file is served properly with UTF-8", (t) => {
 
 	return writeResource(readerWriter, "/myFile3.properties", 1024 * 1024, "key=titel\nfame=straße", "utf8", project)
 		.then((resource) => {
-			const setStringSpy = sinon.spy(resource, "setString");
+			let setStringSpy;
+			let clonedResource;
+			modifyClone(resource, (clonedResourceInternal) => {
+				setStringSpy = sinon.spy(clonedResourceInternal, "setString");
+				clonedResource = clonedResourceInternal;
+			});
 			const middleware = serveResourcesMiddleware({
 				middlewareUtil: new MiddlewareUtil(),
 				resources: {
@@ -116,7 +141,7 @@ test.serial("Check if properties file is served properly with UTF-8", (t) => {
 				throw new Error(`Next callback called with error: ${err.message}`);
 			};
 			return middleware(req, response, next).then((o) => {
-				return resource.getString();
+				return clonedResource.getString();
 			}).then((content) => {
 				t.is(content, `key=titel
 fame=stra\\u00dfe`);
@@ -133,7 +158,12 @@ test.serial("Check if properties file is served properly without property settin
 	const readerWriter = resourceFactory.createAdapter({virBasePath: "/"});
 
 	return writeResource(readerWriter, "/myFile3.properties", 1024 * 1024, "key=titel\nfame=straße", "utf8").then((resource) => {
-		const setStringSpy = sinon.spy(resource, "setString");
+		let setStringSpy;
+		let clonedResource;
+		modifyClone(resource, (clonedResourceInternal) => {
+			setStringSpy = sinon.spy(clonedResourceInternal, "setString");
+			clonedResource = clonedResourceInternal;
+		});
 		const middleware = serveResourcesMiddleware({
 			middlewareUtil: new MiddlewareUtil(),
 			resources: {
@@ -152,7 +182,7 @@ test.serial("Check if properties file is served properly without property settin
 			throw new Error(`Next callback called with error: ${err.stack}`);
 		};
 		return middleware(req, response, next).then((o) => {
-			return resource.getString();
+			return clonedResource.getString();
 		}).then((content) => {
 			t.is(content, `key=titel
 fame=stra\\u00dfe`);
@@ -171,7 +201,12 @@ test.serial("Check if properties file is served properly without property settin
 		specVersion: "1.1"
 	};
 	return writeResource(readerWriter, "/myFile3.properties", 1024 * 1024, "key=titel\nfame=straße", "latin1", project).then((resource) => {
-		const setStringSpy = sinon.spy(resource, "setString");
+		let setStringSpy;
+		let clonedResource;
+		modifyClone(resource, (clonedResourceInternal) => {
+			setStringSpy = sinon.spy(clonedResourceInternal, "setString");
+			clonedResource = clonedResourceInternal;
+		});
 		const middleware = serveResourcesMiddleware({
 			middlewareUtil: new MiddlewareUtil(),
 			resources: {
@@ -190,7 +225,7 @@ test.serial("Check if properties file is served properly without property settin
 			throw new Error(`Next callback called with error: ${err.stack}`);
 		};
 		return middleware(req, response, next).then((o) => {
-			return resource.getString();
+			return clonedResource.getString();
 		}).then((content) => {
 			t.is(content, `key=titel
 fame=stra\\u00dfe`);
@@ -209,7 +244,12 @@ test.serial("Check if properties file is served properly without property settin
 		specVersion: "2.0"
 	};
 	return writeResource(readerWriter, "/myFile3.properties", 1024 * 1024, "key=titel\nfame=straße", "utf8", project).then((resource) => {
-		const setStringSpy = sinon.spy(resource, "setString");
+		let setStringSpy;
+		let clonedResource;
+		modifyClone(resource, (clonedResourceInternal) => {
+			setStringSpy = sinon.spy(clonedResourceInternal, "setString");
+			clonedResource = clonedResourceInternal;
+		});
 		const middleware = serveResourcesMiddleware({
 			middlewareUtil: new MiddlewareUtil(),
 			resources: {
@@ -228,7 +268,7 @@ test.serial("Check if properties file is served properly without property settin
 			throw new Error(`Next callback called with error: ${err.stack}`);
 		};
 		return middleware(req, response, next).then((o) => {
-			return resource.getString();
+			return clonedResource.getString();
 		}).then((content) => {
 			t.is(content, `key=titel
 fame=stra\\u00dfe`);


### PR DESCRIPTION
Fix ui5-server tests in combination which broke with https://github.com/SAP/ui5-fs/issues/235
Adjust stubs such that they operate on the cloned
resource instead of the original.

* serveIndex: instead of stubbing directly pass the statInfo object such that it gets cloned
* serveResources: ensure the "right" resources are returned by the `byPath` lookup

Fixes: https://github.com/SAP/ui5-fs/issues/250