### PR TITLE
[FIX] TypeScript type definition support

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,26 +2,34 @@
  * @module @ui5/server
  * @public
  */
-const modules = {
+module.exports = {
+	/**
+	 * @type {import('./lib/server')}
+	 */
 	server: "./lib/server",
+	/**
+	 * @type {import('./lib/sslUtil')}
+	 */
 	sslUtil: "./lib/sslUtil",
+	/**
+	 * @type {import('./lib/middleware/middlewareRepository')}
+	 */
 	middlewareRepository: "./lib/middleware/middlewareRepository"
 };
 
 function exportModules(exportRoot, modulePaths) {
-	for (const moduleName in modulePaths) {
-		if (Object.prototype.hasOwnProperty.call(modulePaths, moduleName)) {
-			if (typeof modulePaths[moduleName] === "object") {
-				exportRoot[moduleName] = {};
-				exportModules(exportRoot[moduleName], modulePaths[moduleName]);
-			} else {
-				Object.defineProperty(exportRoot, moduleName, {
-					get() {
-						return require(modulePaths[moduleName]);
-					}
-				});
-			}
+	for (const moduleName of Object.keys(modulePaths)) {
+		if (typeof modulePaths[moduleName] === "object") {
+			exportRoot[moduleName] = {};
+			exportModules(exportRoot[moduleName], modulePaths[moduleName]);
+		} else {
+			Object.defineProperty(exportRoot, moduleName, {
+				get() {
+					return require(modulePaths[moduleName]);
+				}
+			});
 		}
 	}
 }
-exportModules(module.exports, modules);
+
+exportModules(module.exports, JSON.parse(JSON.stringify(module.exports)));

--- a/jsdoc-plugin.js
+++ b/jsdoc-plugin.js
@@ -1,0 +1,13 @@
+/*
+ * Removes JSDoc comments with TypeScript import() declarations (used in index.js)
+ */
+
+const IMPORT_PATTERN = /{(?:typeof )?import\(["'][^"']*["']\)[ .|}><,)=#\n]/;
+
+exports.handlers = {
+	jsdocCommentFound: function(e) {
+		if (IMPORT_PATTERN.test(e.comment)) {
+			e.comment = "";
+		}
+	}
+};

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,60 +1,62 @@
 {
-    "tags": {
-        "allowUnknownTags": false
-    },
-    "source": {
-        "include": ["README.md", "index.js"],
-        "includePattern": ".+\\.js$",
-        "excludePattern": "(node_modules(\\\\|/))"
-    },
-    "plugins": [],
-    "opts": {
-        "template": "node_modules/docdash/",
-        "encoding": "utf8",
-        "destination": "jsdocs/",
-        "recurse": true,
-        "verbose": true,
-        "access": "public"
-    },
-    "templates": {
-        "cleverLinks": false,
-        "monospaceLinks": false,
-        "default": {
-            "useLongnameInNav": true
-        }
-    },
-    "openGraph": {
-        "title": "UI5 Tooling - API Reference",
-        "type": "website",
-        "image": "https://sap.github.io/ui5-tooling/docs/images/UI5_logo_wide.png",
-        "site_name": "UI5 Tooling - API Reference",
-        "url": "https://sap.github.io/ui5-tooling/"
-    },
-    "docdash": {
-        "sectionOrder": [
-            "Modules",
-            "Namespaces",
-            "Classes",
-            "Externals",
-            "Events",
-            "Mixins",
-            "Tutorials",
-            "Interfaces"
-        ],
-        "meta": {
-            "title": "UI5 Tooling - API Reference - UI5 Server",
-            "description": "UI5 Tooling - API Reference - UI5 Server",
-            "keyword": "openui5 sapui5 ui5 build development tool api reference"
-        },
-        "search": true,
-        "wrap": true,
-        "menu": {
-            "GitHub": {
-                "href": "https://github.com/SAP/ui5-server",
-                "target": "_blank",
-                "class": "menu-item",
-                "id": "github_link"
-            }
-        }
-    }
+	"tags": {
+		"allowUnknownTags": false
+	},
+	"source": {
+		"include": ["README.md", "index.js"],
+		"includePattern": ".+\\.js$",
+		"excludePattern": "(node_modules(\\\\|/))"
+	},
+	"plugins": [
+		"./jsdoc-plugin"
+	],
+	"opts": {
+		"template": "node_modules/docdash/",
+		"encoding": "utf8",
+		"destination": "jsdocs/",
+		"recurse": true,
+		"verbose": true,
+		"access": "public"
+	},
+	"templates": {
+		"cleverLinks": false,
+		"monospaceLinks": false,
+		"default": {
+			"useLongnameInNav": true
+		}
+	},
+	"openGraph": {
+		"title": "UI5 Tooling - API Reference",
+		"type": "website",
+		"image": "https://sap.github.io/ui5-tooling/docs/images/UI5_logo_wide.png",
+		"site_name": "UI5 Tooling - API Reference",
+		"url": "https://sap.github.io/ui5-tooling/"
+	},
+	"docdash": {
+		"sectionOrder": [
+			"Modules",
+			"Namespaces",
+			"Classes",
+			"Externals",
+			"Events",
+			"Mixins",
+			"Tutorials",
+			"Interfaces"
+		],
+		"meta": {
+			"title": "UI5 Tooling - API Reference - UI5 Server",
+			"description": "UI5 Tooling - API Reference - UI5 Server",
+			"keyword": "openui5 sapui5 ui5 build development tool api reference"
+		},
+		"search": true,
+		"wrap": true,
+		"menu": {
+			"GitHub": {
+				"href": "https://github.com/SAP/ui5-server",
+				"target": "_blank",
+				"class": "menu-item",
+				"id": "github_link"
+			}
+		}
+	}
 }


### PR DESCRIPTION
Lazy-loading breaks the automatic type definition detection from

TypeScript. Therefore we need to manually declare the exported types.