### PR TITLE
[INTERNAL] MiddlewareUtil: Support specVersion 2.2

### DIFF
--- a/lib/middleware/MiddlewareManager.js
+++ b/lib/middleware/MiddlewareManager.js
@@ -206,7 +206,7 @@ class MiddlewareManager {
 							configuration: middlewareDef.configuration
 						};
 						const params = {resources, options};
-						if (specVersion === "2.0" || specVersion === "2.1") {
+						if (specVersion === "2.0" || specVersion === "2.1" || specVersion === "2.2") {
 							// Supply interface to MiddlewareUtil instance starting with specVersion 2.0
 							params.middlewareUtil = middlewareUtil.getInterface(specVersion);
 						}

--- a/lib/middleware/MiddlewareUtil.js
+++ b/lib/middleware/MiddlewareUtil.js
@@ -33,7 +33,7 @@ class MiddlewareUtil {
 		case "2.2":
 			return baseInterface;
 		default:
-			throw new Error(`MiddlewareUtil: Unknown or unsupported specification version ${specVersion}`);
+			throw new Error(`MiddlewareUtil: Unknown or unsupported Specification Version ${specVersion}`);
 		}
 	}
 
@@ -42,7 +42,7 @@ class MiddlewareUtil {
 	 * of a given request. Any escape sequences will be decoded.
 	 * </br></br>
 	 * This method is only available to custom middleware extensions defining
-	 * <b>specification version 2.0 and above</b>.
+	 * <b>Specification Version 2.0 and above</b>.
 	 *
 	 * @param {object} req Request object
 	 * @returns {string} [Pathname]{@link https://developer.mozilla.org/en-US/docs/Web/API/URL/pathname}
@@ -77,7 +77,7 @@ class MiddlewareUtil {
 	 * Returns MIME information derived from a given resource path.
 	 * </br></br>
 	 * This method is only available to custom middleware extensions defining
-	 * <b>specification version 2.0 and above</b>.
+	 * <b>Specification Version 2.0 and above</b>.
 	 *
 	 * @param {object} resourcePath
 	 * @returns {module:@ui5/server.middleware.MiddlewareUtil.MimeInfo}

--- a/lib/middleware/MiddlewareUtil.js
+++ b/lib/middleware/MiddlewareUtil.js
@@ -30,6 +30,7 @@ class MiddlewareUtil {
 			return undefined;
 		case "2.0":
 		case "2.1":
+		case "2.2":
 			return baseInterface;
 		default:
 			throw new Error(`MiddlewareUtil: Unknown or unsupported specification version ${specVersion}`);

--- a/test/lib/server/middleware/MiddlewareUtil.js
+++ b/test/lib/server/middleware/MiddlewareUtil.js
@@ -79,6 +79,34 @@ test("getInterface: specVersion 2.0", async (t) => {
 	t.is(typeof interfacedMiddlewareUtil.getMimeInfo, "function", "function getMimeInfo is provided");
 });
 
+test("getInterface: specVersion 2.1", async (t) => {
+	const middlewareUtil = new MiddlewareUtil();
+
+	const interfacedMiddlewareUtil = middlewareUtil.getInterface("2.1");
+
+	t.deepEqual(Object.keys(interfacedMiddlewareUtil), [
+		"getPathname",
+		"getMimeInfo"
+	], "Correct methods are provided");
+
+	t.is(typeof interfacedMiddlewareUtil.getPathname, "function", "function getPathname is provided");
+	t.is(typeof interfacedMiddlewareUtil.getMimeInfo, "function", "function getMimeInfo is provided");
+});
+
+test("getInterface: specVersion 2.2", async (t) => {
+	const middlewareUtil = new MiddlewareUtil();
+
+	const interfacedMiddlewareUtil = middlewareUtil.getInterface("2.2");
+
+	t.deepEqual(Object.keys(interfacedMiddlewareUtil), [
+		"getPathname",
+		"getMimeInfo"
+	], "Correct methods are provided");
+
+	t.is(typeof interfacedMiddlewareUtil.getPathname, "function", "function getPathname is provided");
+	t.is(typeof interfacedMiddlewareUtil.getMimeInfo, "function", "function getMimeInfo is provided");
+});
+
 test("getInterface: specVersion undefined", async (t) => {
 	const middlewareUtil = new MiddlewareUtil();
 

--- a/test/lib/server/middleware/MiddlewareUtil.js
+++ b/test/lib/server/middleware/MiddlewareUtil.js
@@ -114,7 +114,7 @@ test("getInterface: specVersion undefined", async (t) => {
 		middlewareUtil.getInterface();
 	});
 
-	t.is(err.message, "MiddlewareUtil: Unknown or unsupported specification version undefined",
+	t.is(err.message, "MiddlewareUtil: Unknown or unsupported Specification Version undefined",
 		"Throw with correct error message");
 });
 
@@ -124,6 +124,6 @@ test("getInterface: specVersion unknown", async (t) => {
 		middlewareUtil.getInterface("1.5");
 	});
 
-	t.is(err.message, "MiddlewareUtil: Unknown or unsupported specification version 1.5",
+	t.is(err.message, "MiddlewareUtil: Unknown or unsupported Specification Version 1.5",
 		"Throw with correct error message");
 });


### PR DESCRIPTION
New specVersion does not affect MiddlewareUtil but still needs to be
supported and handled.
