### PR TITLE
[INTERNAL] Fix missing peerDependency to acorn / Add CI check

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,9 @@ steps:
 - script: npm ci
   displayName: Install Dependencies
 
+- script: npm ls
+  displayName: Check for missing / extraneous Dependencies
+
 - script: npm run test-azure
   displayName: Run Tests
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -678,9 +678,9 @@
 			}
 		},
 		"acorn": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.1.tgz",
-			"integrity": "sha512-dmKn4pqZ29iQl2Pvze1zTrps2luvls2PBY//neO2WJ0s10B3AxJXshN+Ph7B4GrhfGhHXrl4dnUwyNNXQcnWGQ==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+			"integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
 			"dev": true
 		},
 		"acorn-jsx": {
@@ -690,9 +690,9 @@
 			"dev": true
 		},
 		"acorn-walk": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.0.0.tgz",
-			"integrity": "sha512-oZRad/3SMOI/pxbbmqyurIx7jHw1wZDcR9G44L8pUVFEomX/0dH89SrM1KaDXuv1NpzAXz6Op/Xu/Qd5XXzdEA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+			"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
 			"dev": true
 		},
 		"agent-base": {
@@ -928,20 +928,20 @@
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
 		},
 		"ava": {
-			"version": "3.12.1",
-			"resolved": "https://registry.npmjs.org/ava/-/ava-3.12.1.tgz",
-			"integrity": "sha512-cS41+X+UfrcPed+CIgne/YV/6eWxaUjHEPH+W8WvNSqWTWku5YitjZGE5cMHFuJxwHELdR541xTBRn8Uwi4PSw==",
+			"version": "3.11.1",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-3.11.1.tgz",
+			"integrity": "sha512-yGPD0msa5Qronw7GHDNlLaB7oU5zryYtXeuvny40YV6TMskSghqK7Ky3NisM/sr+aqI3DY7sfmORx8dIWQgMoQ==",
 			"dev": true,
 			"requires": {
 				"@concordance/react": "^2.0.0",
-				"acorn": "^8.0.1",
-				"acorn-walk": "^8.0.0",
+				"acorn": "^7.3.1",
+				"acorn-walk": "^7.2.0",
 				"ansi-styles": "^4.2.1",
 				"arrgv": "^1.0.2",
 				"arrify": "^2.0.1",
 				"callsites": "^3.1.0",
 				"chalk": "^4.1.0",
-				"chokidar": "^3.4.2",
+				"chokidar": "^3.4.1",
 				"chunkd": "^2.0.1",
 				"ci-info": "^2.0.0",
 				"ci-parallel-vars": "^1.0.1",
@@ -950,7 +950,7 @@
 				"cli-truncate": "^2.1.0",
 				"code-excerpt": "^3.0.0",
 				"common-path-prefix": "^3.0.0",
-				"concordance": "^5.0.1",
+				"concordance": "^5.0.0",
 				"convert-source-map": "^1.7.0",
 				"currently-unhandled": "^0.4.1",
 				"debug": "^4.1.1",
@@ -965,12 +965,12 @@
 				"is-error": "^2.2.2",
 				"is-plain-object": "^4.1.1",
 				"is-promise": "^4.0.0",
-				"lodash": "^4.17.20",
+				"lodash": "^4.17.19",
 				"matcher": "^3.0.0",
 				"md5-hex": "^3.0.1",
 				"mem": "^6.1.0",
 				"ms": "^2.1.2",
-				"ora": "^5.0.0",
+				"ora": "^4.0.5",
 				"p-map": "^4.0.0",
 				"picomatch": "^2.2.2",
 				"pkg-conf": "^3.1.0",
@@ -985,7 +985,7 @@
 				"supertap": "^1.0.0",
 				"temp-dir": "^2.0.0",
 				"trim-off-newlines": "^1.0.1",
-				"update-notifier": "^4.1.1",
+				"update-notifier": "^4.1.0",
 				"write-file-atomic": "^3.0.3",
 				"yargs": "^15.4.1"
 			},
@@ -1550,9 +1550,9 @@
 			"dev": true
 		},
 		"cli-boxes": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
-			"integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+			"integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
 			"dev": true
 		},
 		"cli-cursor": {
@@ -4475,12 +4475,70 @@
 			"dev": true
 		},
 		"log-symbols": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-			"integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+			"integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^4.0.0"
+				"chalk": "^2.4.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"lowercase-keys": {
@@ -5248,16 +5306,16 @@
 			}
 		},
 		"ora": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-5.0.0.tgz",
-			"integrity": "sha512-s26qdWqke2kjN/wC4dy+IQPBIMWBJlSU/0JZhk30ZDBLelW25rv66yutUWARMigpGPzcXHb+Nac5pNhN/WsARw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
+			"integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
 			"dev": true,
 			"requires": {
-				"chalk": "^4.1.0",
+				"chalk": "^3.0.0",
 				"cli-cursor": "^3.1.0",
-				"cli-spinners": "^2.4.0",
+				"cli-spinners": "^2.2.0",
 				"is-interactive": "^1.0.0",
-				"log-symbols": "^4.0.0",
+				"log-symbols": "^3.0.0",
 				"mute-stream": "0.0.8",
 				"strip-ansi": "^6.0.0",
 				"wcwidth": "^1.0.1"
@@ -5268,6 +5326,16 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 					"dev": true
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
 				},
 				"strip-ansi": {
 					"version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
 	},
 	"devDependencies": {
 		"@ui5/project": "^2.2.0",
-		"ava": "^3.12.1",
+		"ava": "3.11.1",
 		"chokidar-cli": "^2.1.0",
 		"coveralls": "^3.1.0",
 		"cross-env": "^7.0.2",


### PR DESCRIPTION
Due to a bug in npm, acorn-jsx can't find the correct version of acorn.

Downgrading to ava@3.11 solves the issue as only one acorn version (v7) is present.

Also adding an 'npm ls' check to detect such issues before they get merged into master.