### PR TITLE
[FIX] Discovery middleware shouldn't fail when lib names overlap

### DIFF
--- a/lib/middleware/discovery.js
+++ b/lib/middleware/discovery.js
@@ -83,20 +83,22 @@ function createMiddleware({resources}) {
 					const match = librariesPattern.exec(relPath);
 					if (match) {
 						const lib = match[1];
-						libs[lib] = lib.replace(/\//g, ".");
+						libs[lib + "/"] = lib.replace(/\//g, ".");
 					}
 				});
 
+				const libPrefixes = Object.keys(libs).sort().reverse();
 				testPageResources.forEach(function(resource) {
 					const relPath = resource.getPath().substr(16); // cut off leading "/test-resources/"
 					if (testPagesPattern.test(relPath)) {
-						Object.keys(libs).forEach(function(lib) {
-							if (relPath.indexOf(lib) === 0) {
+						libPrefixes.some(function(lib) {
+							if (relPath.startsWith(lib)) {
 								response.push({
 									lib: libs[lib],
-									name: relPath.substr(lib.length + 1),
+									name: relPath.substr(lib.length),
 									url: "../" + relPath
 								});
+								return true; // abort loop
 							}
 						});
 					}


### PR DESCRIPTION
When a library's name is a prefix of another library's name (like with
sap.m and sap.me), the discovery service mistakenly assigned test pages
to both libraries.

By including the slash in the prefix check, only full segment matches
will be taken into account.

By checking the prefixes from longest to shortest and by aborting after
the first match, non-prefix-free lib names can be handled properly. The
longest matching prefix will win and there won't be double assignments.

**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [ ] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
