### PR TITLE
[INTERNAL] MiddlewareUtil: Support specVersion 2.3

### DIFF
--- a/lib/middleware/MiddlewareManager.js
+++ b/lib/middleware/MiddlewareManager.js
@@ -215,7 +215,10 @@ class MiddlewareManager {
 							configuration: middlewareDef.configuration
 						};
 						const params = {resources, options};
-						if (specVersion === "2.0" || specVersion === "2.1" || specVersion === "2.2") {
+						if (
+							specVersion === "2.0" || specVersion === "2.1" ||
+							specVersion === "2.2" || specVersion === "2.3"
+						) {
 							// Supply interface to MiddlewareUtil instance starting with specVersion 2.0
 							params.middlewareUtil = middlewareUtil.getInterface(specVersion);
 						}

--- a/lib/middleware/MiddlewareUtil.js
+++ b/lib/middleware/MiddlewareUtil.js
@@ -31,6 +31,7 @@ class MiddlewareUtil {
 		case "2.0":
 		case "2.1":
 		case "2.2":
+		case "2.3":
 			return baseInterface;
 		default:
 			throw new Error(`MiddlewareUtil: Unknown or unsupported Specification Version ${specVersion}`);

--- a/test/lib/server/middleware/MiddlewareUtil.js
+++ b/test/lib/server/middleware/MiddlewareUtil.js
@@ -107,6 +107,20 @@ test("getInterface: specVersion 2.2", async (t) => {
 	t.is(typeof interfacedMiddlewareUtil.getMimeInfo, "function", "function getMimeInfo is provided");
 });
 
+test("getInterface: specVersion 2.3", async (t) => {
+	const middlewareUtil = new MiddlewareUtil();
+
+	const interfacedMiddlewareUtil = middlewareUtil.getInterface("2.3");
+
+	t.deepEqual(Object.keys(interfacedMiddlewareUtil), [
+		"getPathname",
+		"getMimeInfo"
+	], "Correct methods are provided");
+
+	t.is(typeof interfacedMiddlewareUtil.getPathname, "function", "function getPathname is provided");
+	t.is(typeof interfacedMiddlewareUtil.getMimeInfo, "function", "function getMimeInfo is provided");
+});
+
 test("getInterface: specVersion undefined", async (t) => {
 	const middlewareUtil = new MiddlewareUtil();
 


### PR DESCRIPTION
New specVersion does not affect MiddlewareUtil but still needs to be
supported and handled.
