### PR TITLE
[INTERNAL] Azure: Only check productive npm dependencies

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ steps:
 - script: npm ci
   displayName: Install Dependencies
 
-- script: npm ls
+- script: npm ls --prod
   displayName: Check for missing / extraneous Dependencies
 
 - script: npm run test-azure


### PR DESCRIPTION
Should resolve failures caused by missing peer-deps of devDependencies