### PR TITLE
[INTERNAL] Azure: Re-run coverage test only

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,6 @@ steps:
     codeCoverageTool: 'cobertura'
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/coverage/cobertura-coverage.xml'
 
-- script: npm run test
+- script: npm run coverage
   displayName: Run Test Natively in Case of Failures
   condition: failed()


### PR DESCRIPTION
ESLint and other checks are covered via GH Actions.
