### PR TITLE
[INTERNAL] Enable azure pipeline config for v2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,58 @@
+# Node.js
+# Build a general Node.js project with npm.
+# Add steps that analyze code, save build artifacts, deploy, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
+
+trigger:
+- v2
+
+strategy:
+  matrix:
+    linux_node_lts_16:
+      imageName: 'ubuntu-20.04'
+      node_version: 16.x
+    linux_node_latest:
+      imageName: 'ubuntu-20.04'
+      node_version: 18.x
+    mac_node_latest:
+      imageName: 'macOS-11'
+      node_version: 18.x
+    windows_node_latest:
+      imageName: 'windows-2022'
+      node_version: 18.x
+
+pool:
+  vmImage: $(imageName)
+
+steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: $(node_version)
+  displayName: Install Node.js
+
+- script: npm ci
+  displayName: Install Dependencies
+
+- script: npm ls --prod
+  displayName: Check for missing / extraneous Dependencies
+
+- script: npm run test-azure
+  displayName: Run Tests
+
+- task: PublishTestResults@2
+  displayName: Publish Test Results
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: 'JUnit'
+    testResultsFiles: '$(System.DefaultWorkingDirectory)/test-results.xml'
+
+- task: PublishCodeCoverageResults@1
+  displayName: Publish Test Coverage Results
+  condition: succeededOrFailed()
+  inputs:
+    codeCoverageTool: 'cobertura'
+    summaryFileLocation: '$(System.DefaultWorkingDirectory)/coverage/cobertura-coverage.xml'
+
+- script: npm run coverage
+  displayName: Run Test Natively in Case of Failures
+  condition: failed()


### PR DESCRIPTION
According to Azure [documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/pipeline-triggers?view=azure-devops#branch-considerations) the v2 branch has to be maintained in the branch config in the default branch so azure knows that a job has to be started. However the actual job is read from the v2 branch. Therefore adding the azure job config again into the v2 branch.