### PR TITLE
[INTERNAL] serveResources: Remove treeify dependency

### DIFF
--- a/lib/middleware/serveResources.js
+++ b/lib/middleware/serveResources.js
@@ -33,12 +33,6 @@ function createMiddleware({resources, middlewareUtil}) {
 				next();
 				return;
 			}
-			if (log.isLevelEnabled("verbose")) {
-				const {
-					default: treeify
-				} = await import("treeify");
-				log.verbose("\n" + treeify.asTree(resource.getPathTree()));
-			}
 
 			const resourcePath = resource.getPath();
 			if (rProperties.test(resourcePath)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
 				"replacestream": "^4.0.3",
 				"router": "^1.3.7",
 				"spdy": "^4.0.2",
-				"treeify": "^1.1.0",
 				"yesno": "^0.3.1"
 			},
 			"devDependencies": {
@@ -9675,14 +9674,6 @@
 				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
-		"node_modules/treeify": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
-			"integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
 		"node_modules/trim-newlines": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
@@ -17734,11 +17725,6 @@
 				"@tokenizer/token": "^0.3.0",
 				"ieee754": "^1.2.1"
 			}
-		},
-		"treeify": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
-			"integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A=="
 		},
 		"trim-newlines": {
 			"version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
 		"replacestream": "^4.0.3",
 		"router": "^1.3.7",
 		"spdy": "^4.0.2",
-		"treeify": "^1.1.0",
 		"yesno": "^0.3.1"
 	},
 	"devDependencies": {

--- a/test/lib/server/middleware/serveResources.js
+++ b/test/lib/server/middleware/serveResources.js
@@ -278,16 +278,6 @@ test.serial("Check verbose logging", async (t) => {
 			return {
 				getVersion: () => "1.0.0"
 			};
-		},
-		getPathTree: () => {
-			return {
-				"mypath": {
-					"a": {
-						"b": {}
-					}
-
-				}
-			};
 		}
 	};
 
@@ -314,11 +304,7 @@ test.serial("Check verbose logging", async (t) => {
 		res.getHeader = sinon.stub();
 		res._write = sinon.stub();
 		res.end = function() {
-			t.is(verboseLogStub.callCount, 1, "was called once");
-			const expected = "\n└─ mypath\n" +
-				"   └─ a\n" +
-				"      └─ b\n";
-			t.deepEqual(verboseLogStub.getCall(0).args, [expected], "treeify works correctly");
+			t.is(verboseLogStub.callCount, 0, "Currently no verbose logging");
 			resolve();
 		};
 


### PR DESCRIPTION
Dependency was already removed from UI5 CLI and tracing will be
re-worked anyways. This serves too-little purpose.