### PR TITLE
[INTERNAL] MiddlewareUtil: Provide resourceFactory#createReaderCollection

### DIFF
--- a/lib/middleware/MiddlewareUtil.js
+++ b/lib/middleware/MiddlewareUtil.js
@@ -1,6 +1,7 @@
 import parseurl from "parseurl";
 import mime from "mime-types";
 import {
+	createReaderCollection,
 	createReaderCollectionPrioritized,
 	createResource,
 	createFilterReader,
@@ -156,6 +157,8 @@ class MiddlewareUtil {
 	 * @typedef {object} @ui5/project/build/helpers/MiddlewareUtill~resourceFactory
 	 * @property {Function} createResource Creates a [Resource]{@link @ui5/fs/Resource}.
 	 * 	Accepts the same parameters as the [Resource]{@link @ui5/fs/Resource} constructor.
+	 * @property {Function} createReaderCollection Creates a reader collection:
+	 *	[ReaderCollection]{@link @ui5/fs/ReaderCollection}
 	 * @property {Function} createReaderCollectionPrioritized Creates a prioritized reader collection:
 	 *	[ReaderCollectionPrioritized]{@link @ui5/fs/ReaderCollectionPrioritized}
 	 * @property {Function} createFilterReader
@@ -178,6 +181,7 @@ class MiddlewareUtil {
 	 */
 	resourceFactory = {
 		createResource,
+		createReaderCollection,
 		createReaderCollectionPrioritized,
 		createFilterReader,
 		createLinkReader,
@@ -223,7 +227,7 @@ class MiddlewareUtil {
 			[
 				// Once new functions get added, extract this array into a variable
 				// and enhance based on spec version once new functions get added
-				"createResource", "createReaderCollectionPrioritized",
+				"createResource", "createReaderCollection", "createReaderCollectionPrioritized",
 				"createFilterReader", "createLinkReader", "createFlatReader",
 			].forEach((factoryFunction) => {
 				baseInterface.resourceFactory[factoryFunction] = this.resourceFactory[factoryFunction];

--- a/test/lib/server/middleware/MiddlewareUtil.js
+++ b/test/lib/server/middleware/MiddlewareUtil.js
@@ -144,6 +144,8 @@ test.serial("resourceFactory", (t) => {
 	const {resourceFactory} = new MiddlewareUtil({graph: "graph", project: "project"});
 	t.is(typeof resourceFactory.createResource, "function",
 		"resourceFactory function createResource is available");
+	t.is(typeof resourceFactory.createReaderCollection, "function",
+		"resourceFactory function createReaderCollection is available");
 	t.is(typeof resourceFactory.createReaderCollectionPrioritized, "function",
 		"resourceFactory function createReaderCollectionPrioritized is available");
 	t.is(typeof resourceFactory.createFilterReader, "function",
@@ -330,6 +332,8 @@ test("getInterface: specVersion 3.0", (t) => {
 	const resourceFactory = interfacedMiddlewareUtil.resourceFactory;
 	t.is(typeof resourceFactory.createResource, "function",
 		"resourceFactory function createResource is available");
+	t.is(typeof resourceFactory.createReaderCollection, "function",
+		"resourceFactory function createReaderCollection is available");
 	t.is(typeof resourceFactory.createReaderCollectionPrioritized, "function",
 		"resourceFactory function createReaderCollectionPrioritized is available");
 	t.is(typeof resourceFactory.createFilterReader, "function",


### PR DESCRIPTION
Follow-up of https://github.com/SAP/ui5-server/pull/547 where this method was somehow missed