### PR TITLE
[BREAKING] Remove "/proxy" endpoint

### DIFF
--- a/lib/middleware/MiddlewareManager.js
+++ b/lib/middleware/MiddlewareManager.js
@@ -104,8 +104,6 @@ class MiddlewareManager {
 					`in project ${this.middlewareUtil.getProject()}, ` +
 					`has been removed in this version of UI5 Tooling and can't be referenced anymore. ` +
 					`Please see the migration guide at https://sap.github.io/ui5-tooling/updates/migrate-v3/`);
-
-				refMiddlewareIdx = this.middlewareExecutionOrder.indexOf("nonReadRequests");
 			}
 			if (refMiddlewareIdx === -1) {
 				throw new Error(`Could not find middleware ${refMiddlewareName}, referenced by custom ` +

--- a/lib/middleware/MiddlewareManager.js
+++ b/lib/middleware/MiddlewareManager.js
@@ -223,9 +223,6 @@ class MiddlewareManager {
 				};
 			}
 		});
-		await this.addMiddleware("connectUi5Proxy", {
-			mountPath: "/proxy"
-		});
 		// Handle anything but read operations *before* the serveIndex middleware
 		//	as it will reject them with a 405 (Method not allowed) instead of 404 like our old tooling
 		await this.addMiddleware("nonReadRequests");

--- a/lib/middleware/MiddlewareManager.js
+++ b/lib/middleware/MiddlewareManager.js
@@ -98,8 +98,7 @@ class MiddlewareManager {
 			let refMiddlewareIdx = this.middlewareExecutionOrder.indexOf(refMiddlewareName);
 
 			if (refMiddlewareName === "connectUi5Proxy") {
-				const log = logger.getGroupLogger(`server:custom-middleware:${middlewareName}`);
-				log.warn(
+				throw new Error(
 					`Standard middleware "connectUi5Proxy", referenced by middleware "${middlewareName}" ` +
 					`in project ${this.middlewareUtil.getProject()}, ` +
 					`has been removed in this version of UI5 Tooling and can't be referenced anymore. ` +

--- a/lib/middleware/MiddlewareManager.js
+++ b/lib/middleware/MiddlewareManager.js
@@ -105,7 +105,7 @@ class MiddlewareManager {
 					`has been removed in this version of UI5 Tooling and can't be referenced anymore. ` +
 					`Please see the migration guide at https://sap.github.io/ui5-tooling/updates/migrate-v3/`);
 
-				refMiddlewareIdx = this.middlewareExecutionOrder.length; // push
+				refMiddlewareIdx = this.middlewareExecutionOrder.indexOf("nonReadRequests");
 			}
 			if (refMiddlewareIdx === -1) {
 				throw new Error(`Could not find middleware ${refMiddlewareName}, referenced by custom ` +

--- a/lib/middleware/MiddlewareManager.js
+++ b/lib/middleware/MiddlewareManager.js
@@ -96,6 +96,17 @@ class MiddlewareManager {
 		if (beforeMiddleware || afterMiddleware) {
 			const refMiddlewareName = beforeMiddleware || afterMiddleware;
 			let refMiddlewareIdx = this.middlewareExecutionOrder.indexOf(refMiddlewareName);
+
+			if (refMiddlewareName === "connectUi5Proxy") {
+				const log = logger.getGroupLogger(`server:custom-middleware:${middlewareName}`);
+				log.warn(
+					`Standard middleware "connectUi5Proxy", referenced by middleware "${middlewareName}" ` +
+					`in project ${this.middlewareUtil.getProject()}, ` +
+					`has been removed in this version of UI5 Tooling and can't be referenced anymore. ` +
+					`Please see the migration guide at https://sap.github.io/ui5-tooling/updates/migrate-v3/`);
+
+				refMiddlewareIdx = this.middlewareExecutionOrder.length; // push
+			}
 			if (refMiddlewareIdx === -1) {
 				throw new Error(`Could not find middleware ${refMiddlewareName}, referenced by custom ` +
 					`middleware ${middlewareName}`);

--- a/lib/middleware/connectUi5Proxy.js
+++ b/lib/middleware/connectUi5Proxy.js
@@ -1,9 +1,0 @@
-import ui5connect from "connect-openui5";
-
-function createMiddleware() {
-	return ui5connect.proxy({
-		secure: false
-	});
-}
-
-export default createMiddleware;

--- a/lib/middleware/middlewareRepository.js
+++ b/lib/middleware/middlewareRepository.js
@@ -6,7 +6,6 @@ const middlewareInfos = {
 	serveIndex: {path: "./serveIndex.js"},
 	discovery: {path: "./discovery.js"},
 	versionInfo: {path: "./versionInfo.js"},
-	connectUi5Proxy: {path: "./connectUi5Proxy.js"},
 	serveThemes: {path: "./serveThemes.js"},
 	testRunner: {path: "./testRunner.js"},
 	nonReadRequests: {path: "./nonReadRequests.js"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
 				"@ui5/logger": "^3.0.1-beta.1",
 				"body-parser": "^1.20.1",
 				"compression": "^1.7.4",
-				"connect-openui5": "^0.10.3",
 				"cors": "^2.8.5",
 				"devcert-sanscache": "^0.4.8",
 				"escape-html": "^1.0.3",
@@ -1492,11 +1491,6 @@
 			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
 			"dev": true
 		},
-		"node_modules/async": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
-		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2659,24 +2653,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/connect-openui5": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/connect-openui5/-/connect-openui5-0.10.3.tgz",
-			"integrity": "sha512-7pdGd0bg/dRH8LWZTSXB7GQuZQtwhKspImyDKFcHAMkxlBwJ6YMWmDOlXhQmYzyeoI06sDsD8Nd5bdGmZGN61w==",
-			"dependencies": {
-				"async": "^3.2.4",
-				"cookie": "^0.4.2",
-				"extend": "^3.0.2",
-				"glob": "^7.2.3",
-				"http-proxy": "^1.18.1",
-				"less-openui5": "^0.11.3",
-				"set-cookie-parser": "^2.5.1"
-			},
-			"engines": {
-				"node": ">= 10",
-				"npm": ">= 5"
-			}
-		},
 		"node_modules/console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -2733,14 +2709,6 @@
 			"dev": true,
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			}
-		},
-		"node_modules/cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/cookie-signature": {
@@ -4116,11 +4084,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/eventemitter3": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-		},
 		"node_modules/events": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -4215,11 +4178,6 @@
 					"url": "https://feross.org/support"
 				}
 			]
-		},
-		"node_modules/extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -4426,25 +4384,6 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
-		},
-		"node_modules/follow-redirects": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/RubenVerborgh"
-				}
-			],
-			"engines": {
-				"node": ">=4.0"
-			},
-			"peerDependenciesMeta": {
-				"debug": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/foreground-child": {
 			"version": "2.0.0",
@@ -4975,19 +4914,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/http-proxy": {
-			"version": "1.18.1",
-			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-			"integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-			"dependencies": {
-				"eventemitter3": "^4.0.0",
-				"follow-redirects": "^1.0.0",
-				"requires-port": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/http-proxy-agent": {
@@ -8757,11 +8683,6 @@
 			"integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==",
 			"dev": true
 		},
-		"node_modules/requires-port": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
-		},
 		"node_modules/requizzle": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
@@ -9041,11 +8962,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
-		},
-		"node_modules/set-cookie-parser": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
-			"integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ=="
 		},
 		"node_modules/setprototypeof": {
 			"version": "1.2.0",
@@ -11666,11 +11582,6 @@
 			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
 			"dev": true
 		},
-		"async": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
-		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -12556,20 +12467,6 @@
 				}
 			}
 		},
-		"connect-openui5": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/connect-openui5/-/connect-openui5-0.10.3.tgz",
-			"integrity": "sha512-7pdGd0bg/dRH8LWZTSXB7GQuZQtwhKspImyDKFcHAMkxlBwJ6YMWmDOlXhQmYzyeoI06sDsD8Nd5bdGmZGN61w==",
-			"requires": {
-				"async": "^3.2.4",
-				"cookie": "^0.4.2",
-				"extend": "^3.0.2",
-				"glob": "^7.2.3",
-				"http-proxy": "^1.18.1",
-				"less-openui5": "^0.11.3",
-				"set-cookie-parser": "^2.5.1"
-			}
-		},
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -12606,11 +12503,6 @@
 			"resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
 			"integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
 			"dev": true
-		},
-		"cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
 		},
 		"cookie-signature": {
 			"version": "1.0.6",
@@ -13626,11 +13518,6 @@
 			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
 			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
 		},
-		"eventemitter3": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-		},
 		"events": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -13704,11 +13591,6 @@
 					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 				}
 			}
-		},
-		"extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -13880,11 +13762,6 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
-		},
-		"follow-redirects": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
 		},
 		"foreground-child": {
 			"version": "2.0.0",
@@ -14276,16 +14153,6 @@
 				"setprototypeof": "1.2.0",
 				"statuses": "2.0.1",
 				"toidentifier": "1.0.1"
-			}
-		},
-		"http-proxy": {
-			"version": "1.18.1",
-			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-			"integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-			"requires": {
-				"eventemitter3": "^4.0.0",
-				"follow-redirects": "^1.0.0",
-				"requires-port": "^1.0.0"
 			}
 		},
 		"http-proxy-agent": {
@@ -17051,11 +16918,6 @@
 			"integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==",
 			"dev": true
 		},
-		"requires-port": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
-		},
 		"requizzle": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
@@ -17271,11 +17133,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
-		},
-		"set-cookie-parser": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
-			"integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ=="
 		},
 		"setprototypeof": {
 			"version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
 		"@ui5/logger": "^3.0.1-beta.1",
 		"body-parser": "^1.20.1",
 		"compression": "^1.7.4",
-		"connect-openui5": "^0.10.3",
 		"cors": "^2.8.5",
 		"devcert-sanscache": "^0.4.8",
 		"escape-html": "^1.0.3",

--- a/test/lib/server/middleware/MiddlewareManager.js
+++ b/test/lib/server/middleware/MiddlewareManager.js
@@ -198,7 +198,7 @@ test("addMiddleware: Add middleware with beforeMiddleware=connectUi5Proxy", asyn
 	t.is(
 		middlewareManager.middlewareExecutionOrder.indexOf("customMiddleware"),
 		middlewareManager.middlewareExecutionOrder.indexOf("nonReadRequests") + 1,
-		"customMiddleware was append at the end"
+		"customMiddleware was append after the standard 'nonReadRequests'"
 	);
 
 	t.truthy(

--- a/test/lib/server/middleware/MiddlewareManager.js
+++ b/test/lib/server/middleware/MiddlewareManager.js
@@ -299,7 +299,7 @@ test("addStandardMiddleware: Adds standard middleware in correct order", async (
 	const addMiddlewareStub = sinon.stub(middlewareManager, "addMiddleware").resolves();
 	await middlewareManager.addStandardMiddleware();
 
-	t.is(addMiddlewareStub.callCount, 11, "Expected count of middleware got added");
+	t.is(addMiddlewareStub.callCount, 10, "Expected count of middleware got added");
 	const addedMiddlewareNames = [];
 	for (let i = 0; i < addMiddlewareStub.callCount; i++) {
 		addedMiddlewareNames.push(addMiddlewareStub.getCall(i).args[0]);
@@ -313,7 +313,6 @@ test("addStandardMiddleware: Adds standard middleware in correct order", async (
 		"testRunner",
 		"serveThemes",
 		"versionInfo",
-		"connectUi5Proxy",
 		"nonReadRequests",
 		"serveIndex"
 	], "Correct order of standard middlewares");

--- a/test/lib/server/middleware/MiddlewareManager.js
+++ b/test/lib/server/middleware/MiddlewareManager.js
@@ -188,21 +188,18 @@ test("addMiddleware: Add middleware with beforeMiddleware=connectUi5Proxy", asyn
 		}
 	});
 
-	await middlewareManager.addMiddleware("compression"); // Add some middleware
-	await middlewareManager.addMiddleware("nonReadRequests"); // Add some middleware
-
-	await middlewareManager.addMiddleware("serveIndex", { // Add middleware to test for
-		beforeMiddleware: "connectUi5Proxy",
+	await middlewareManager.addStandardMiddleware(); // Add standard middleware
+	await middlewareManager.addMiddleware("customMiddleware", { // Add middleware to test for
+		customMiddleware: () => {},
+		afterMiddleware: "connectUi5Proxy",
 		mountPath: "/pony"
 	});
-	t.truthy(middlewareManager.middleware["serveIndex"], "Middleware got added to internal map");
-	t.truthy(middlewareManager.middleware["serveIndex"].middleware, "Middleware module is given");
-	t.is(middlewareManager.middleware["serveIndex"].mountPath, "/pony", "Correct mount path set");
 
-	t.is(middlewareManager.middlewareExecutionOrder.length, 3,
-		"Three middleware got added to middleware execution order");
-	t.is(middlewareManager.middlewareExecutionOrder[1], "serveIndex",
-		"Middleware was inserted at the end of middleware execution order array");
+	t.is(
+		middlewareManager.middlewareExecutionOrder.indexOf("customMiddleware"),
+		middlewareManager.middlewareExecutionOrder.indexOf("nonReadRequests") + 1,
+		"customMiddleware was append at the end"
+	);
 
 	t.truthy(
 		warnSpy.calledOnce,

--- a/test/lib/server/middleware/MiddlewareManager.js
+++ b/test/lib/server/middleware/MiddlewareManager.js
@@ -198,13 +198,8 @@ test("addMiddleware: Add middleware with beforeMiddleware=connectUi5Proxy", asyn
 		});
 	});
 
-	t.truthy(
-		warnSpy.calledOnce,
-		"There should be a warning if middleware tries to attach on beforeMiddleware/afterMiddleware 'connectUi5Proxy'"
-	);
-
 	t.is(err.message,
-		"Could not find middleware connectUi5Proxy, referenced by custom middleware customMiddleware",
+		"Standard middleware \"connectUi5Proxy\", referenced by middleware \"customMiddleware\" in project root project, has been removed in this version of UI5 Tooling and can't be referenced anymore. Please see the migration guide at https://sap.github.io/ui5-tooling/updates/migrate-v3/",
 		"Trying to bind to a non-existing standard middleware");
 
 

--- a/test/lib/server/middleware/MiddlewareManager.js
+++ b/test/lib/server/middleware/MiddlewareManager.js
@@ -189,22 +189,24 @@ test("addMiddleware: Add middleware with beforeMiddleware=connectUi5Proxy", asyn
 	});
 
 	await middlewareManager.addStandardMiddleware(); // Add standard middleware
-	await middlewareManager.addMiddleware("customMiddleware", { // Add middleware to test for
-		customMiddleware: () => {},
-		afterMiddleware: "connectUi5Proxy",
-		mountPath: "/pony"
-	});
 
-	t.is(
-		middlewareManager.middlewareExecutionOrder.indexOf("customMiddleware"),
-		middlewareManager.middlewareExecutionOrder.indexOf("nonReadRequests") + 1,
-		"customMiddleware was append after the standard 'nonReadRequests'"
-	);
+	const err = await t.throwsAsync(() => {
+		return middlewareManager.addMiddleware("customMiddleware", { // Add middleware to test for
+			customMiddleware: () => {},
+			afterMiddleware: "connectUi5Proxy",
+			mountPath: "/pony"
+		});
+	});
 
 	t.truthy(
 		warnSpy.calledOnce,
 		"There should be a warning if middleware tries to attach on beforeMiddleware/afterMiddleware 'connectUi5Proxy'"
 	);
+
+	t.is(err.message,
+		"Could not find middleware connectUi5Proxy, referenced by custom middleware customMiddleware",
+		"Trying to bind to a non-existing standard middleware");
+
 
 	esmock.purge(StubbedMiddlewareManager);
 });

--- a/test/lib/server/middleware/MiddlewareManager.js
+++ b/test/lib/server/middleware/MiddlewareManager.js
@@ -189,6 +189,7 @@ test("addMiddleware: Add middleware with beforeMiddleware=connectUi5Proxy", asyn
 	});
 
 	await middlewareManager.addMiddleware("compression"); // Add some middleware
+	await middlewareManager.addMiddleware("nonReadRequests"); // Add some middleware
 
 	await middlewareManager.addMiddleware("serveIndex", { // Add middleware to test for
 		beforeMiddleware: "connectUi5Proxy",
@@ -198,8 +199,8 @@ test("addMiddleware: Add middleware with beforeMiddleware=connectUi5Proxy", asyn
 	t.truthy(middlewareManager.middleware["serveIndex"].middleware, "Middleware module is given");
 	t.is(middlewareManager.middleware["serveIndex"].mountPath, "/pony", "Correct mount path set");
 
-	t.is(middlewareManager.middlewareExecutionOrder.length, 2,
-		"Two middleware got added to middleware execution order");
+	t.is(middlewareManager.middlewareExecutionOrder.length, 3,
+		"Three middleware got added to middleware execution order");
 	t.is(middlewareManager.middlewareExecutionOrder[1], "serveIndex",
 		"Middleware was inserted at the end of middleware execution order array");
 

--- a/test/lib/server/middleware/MiddlewareManager.js
+++ b/test/lib/server/middleware/MiddlewareManager.js
@@ -201,9 +201,6 @@ test("addMiddleware: Add middleware with beforeMiddleware=connectUi5Proxy", asyn
 	t.is(err.message,
 		"Standard middleware \"connectUi5Proxy\", referenced by middleware \"customMiddleware\" in project root project, has been removed in this version of UI5 Tooling and can't be referenced anymore. Please see the migration guide at https://sap.github.io/ui5-tooling/updates/migrate-v3/",
 		"Trying to bind to a non-existing standard middleware");
-
-
-	esmock.purge(StubbedMiddlewareManager);
 });
 
 test("addMiddleware: Add middleware with afterMiddleware parameter", async (t) => {


### PR DESCRIPTION
BREAKING CHANGE:
This removes the "/proxy" endpoint and the corresponding
"connectUi5Proxy" middleware from the standard ui5-server.
Internally, this middleware made use of the connect-openui5 proxy
implementation (https://github.com/SAP/connect-openui5#proxy).

More sophisticated proxy solutions for ui5-server are already available
in the form of custom middleware extensions from the UI5-community.

The UI5 Team might provide a dedicated custom middleware extension,
with similar functionality, in the future.

JIRA: CPOUI5FOUNDATION-598