### PR TITLE
[INTERNAL] Use native fs.mkdir instead of make-dir

### DIFF
--- a/lib/sslUtil.js
+++ b/lib/sslUtil.js
@@ -1,15 +1,9 @@
 import os from "node:os";
-import fs from "node:fs";
-import logger from "@ui5/logger";
-const log = logger.getLogger("server:sslUtil");
-import {promisify} from "node:util";
-
-const stat = promisify(fs.stat);
+import {stat, readFile, writeFile, mkdir} from "node:fs/promises";
 import path from "node:path";
+import logger from "@ui5/logger";
 
-const readFile = promisify(fs.readFile);
-const writeFile = promisify(fs.writeFile);
-
+const log = logger.getLogger("server:sslUtil");
 
 /**
  * @private
@@ -87,13 +81,11 @@ async function createAndInstallCertificate(keyPath, certPath) {
 
 	const {key, cert} = await devCert("UI5Tooling");
 
-	const {default: makeDir} = await import("make-dir");
-
 	await Promise.all([
 		// Write certificates to the ui5 certificate folder
 		// such that they are used by default upon next startup
-		makeDir(path.dirname(keyPath)).then(() => writeFile(keyPath, key)),
-		makeDir(path.dirname(certPath)).then(() => writeFile(certPath, cert))
+		mkdir(path.dirname(keyPath), {recursive: true}).then(() => writeFile(keyPath, key)),
+		mkdir(path.dirname(certPath), {recursive: true}).then(() => writeFile(certPath, cert))
 	]);
 	return {key, cert};
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
 				"express": "^4.18.2",
 				"fresh": "^0.5.2",
 				"graceful-fs": "^4.2.10",
-				"make-dir": "^3.1.0",
 				"mime-types": "^2.1.35",
 				"parseurl": "^1.3.3",
 				"portscanner": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
 		"express": "^4.18.2",
 		"fresh": "^0.5.2",
 		"graceful-fs": "^4.2.10",
-		"make-dir": "^3.1.0",
 		"mime-types": "^2.1.35",
 		"parseurl": "^1.3.3",
 		"portscanner": "^2.2.0",

--- a/test/lib/server/sslUtil.js
+++ b/test/lib/server/sslUtil.js
@@ -21,15 +21,17 @@ function fileExists(filePath) {
 test.beforeEach(async (t) => {
 	t.context.yesno = sinon.stub();
 	t.context.devcertSanscache = sinon.stub();
-	t.context.makeDir = sinon.stub().resolves();
+	t.context.mkdir = sinon.stub().resolves();
 
-	t.context.createSslUtilMock = async (mockMakeDir = false) => {
+	t.context.createSslUtilMock = async (mockMkdir = false) => {
 		const mocks = {
 			"yesno": t.context.yesno,
 			"devcert-sanscache": t.context.devcertSanscache
 		};
-		if (mockMakeDir) {
-			mocks["make-dir"] = t.context.makeDir;
+		if (mockMkdir) {
+			mocks["node:fs/promises"] = {
+				mkdir: t.context.mkdir
+			};
 		}
 		t.context.sslUtil = await esmock.p("../../../lib/sslUtil.js", mocks);
 		return t.context.sslUtil;
@@ -127,7 +129,7 @@ test.serial("Create new certificate and do not install it", async (t) => {
 });
 
 test.serial("Create new certificate not succeeded", async (t) => {
-	const {createSslUtilMock, yesno, devcertSanscache, makeDir} = t.context;
+	const {createSslUtilMock, yesno, devcertSanscache, mkdir} = t.context;
 	const sslUtil = await createSslUtilMock(true);
 
 	t.plan(6);
@@ -149,8 +151,8 @@ test.serial("Create new certificate not succeeded", async (t) => {
 			cert: "bbb"
 		};
 	});
-	makeDir.callsFake(async function(dirName) {
-		t.pass("make-dir mock reached.");
+	mkdir.callsFake(async function(dirName) {
+		t.pass("mkdir mock reached.");
 
 		throw new Error("some error");
 	});


### PR DESCRIPTION
The recursive option is available since Node v10.12, which makes the
use of thirdparty packages obsolete for most use cases.
