### PR TITLE
[INTERNAL] MiddlewareUtil#getProject: Retrieve Project for a given Resource

### DIFF
--- a/lib/middleware/MiddlewareUtil.js
+++ b/lib/middleware/MiddlewareUtil.js
@@ -123,8 +123,8 @@ class MiddlewareUtil {
 	 * Name of the project to retrieve or a Resource instance to retrieve the associated project for.
 	 * Defaults to the name of the current root project
 	 * @returns {@ui5/project/build/helpers/MiddlewareUtill~ProjectInterface|undefined}
-	 * Specification Version-dependent interface to the Project instance or
-	 * undefined if the project name is unknown or the provided resource is not associated with any project.
+	 * Specification Version-dependent interface to the Project instance or <code>undefined</code>
+	 * if the project name is unknown or the provided resource is not associated with any project.
 	 * @public
 	 */
 	getProject(projectNameOrResource) {

--- a/lib/middleware/MiddlewareUtil.js
+++ b/lib/middleware/MiddlewareUtil.js
@@ -119,15 +119,25 @@ class MiddlewareUtil {
 	 * This method is only available to custom server middleware extensions defining
 	 * <b>Specification Version 3.0 and above</b>.
 	 *
-	 * @param {string} [projectName] Name of the project to retrieve. Defaults to the project currently being built
+	 * @param {string|@ui5/fs/Resource} [projectNameOrResource]
+	 * Name of the project to retrieve or a Resource instance to retrieve the associated project for.
+	 * Defaults to the name of the current root project
 	 * @returns {@ui5/project/build/helpers/MiddlewareUtill~ProjectInterface|undefined}
-	 * project instance or undefined if the project is unknown to the graph
+	 * Specification Version-dependent interface to the Project instance or
+	 * undefined if the project name is unknown or the provided resource is not associated with any project.
 	 * @public
 	 */
-	getProject(projectName) {
-		if (projectName) {
-			return this._graph.getProject(projectName);
+	getProject(projectNameOrResource) {
+		if (projectNameOrResource) {
+			if (typeof projectNameOrResource === "string" || projectNameOrResource instanceof String) {
+				// A project name has been provided
+				return this._graph.getProject(projectNameOrResource);
+			} else {
+				// A Resource instance has been provided
+				return projectNameOrResource.getProject();
+			}
 		}
+		// No parameter has been provided, default to the root project
 		return this._project;
 	}
 
@@ -139,7 +149,8 @@ class MiddlewareUtil {
 	 * This method is only available to custom server middleware extensions defining
 	 * <b>Specification Version 3.0 and above</b>.
 	 *
-	 * @param {string} [projectName] Name of the project to retrieve. Defaults to the project currently being built
+	 * @param {string} [projectName] Name of the project to retrieve.
+	 * Defaults to the name of the current root project
 	 * @returns {string[]} Names of all direct dependencies
 	 * @throws {Error} If the requested project is unknown to the graph
 	 * @public

--- a/test/lib/server/middleware/MiddlewareUtil.js
+++ b/test/lib/server/middleware/MiddlewareUtil.js
@@ -64,14 +64,11 @@ test.serial("getMimeInfo: unknown type", (t) => {
 
 test("getProject", (t) => {
 	const getProjectStub = sinon.stub().returns("Pony farm!");
-	const getProjectNameStub = sinon.stub().returns("root project name");
 	const middlewareUtil = new MiddlewareUtil({
 		graph: {
 			getProject: getProjectStub
 		},
-		project: {
-			getName: getProjectNameStub
-		}
+		project: "root project"
 	});
 
 	const res = middlewareUtil.getProject("pony farm");
@@ -79,7 +76,6 @@ test("getProject", (t) => {
 	t.is(getProjectStub.callCount, 1, "ProjectGraph#getProject got called once");
 	t.is(getProjectStub.getCall(0).args[0], "pony farm",
 		"ProjectGraph#getProject got called with correct arguments");
-	t.is(getProjectNameStub.callCount, 0, "#getName of root project has not been called");
 	t.is(res, "Pony farm!", "Correct result");
 });
 
@@ -96,6 +92,25 @@ test("getProject: Default name", (t) => {
 
 	t.is(getProjectStub.callCount, 0, "ProjectGraph#getProject never got called");
 	t.is(res, "root project", "Correct result");
+});
+
+test("getProject: Resource", (t) => {
+	const getProjectStub = sinon.stub().returns("Pony farm!");
+	const middlewareUtil = new MiddlewareUtil({
+		graph: {
+			getProject: getProjectStub
+		},
+		project: "root project"
+	});
+
+	const mockResource = {
+		getProject: sinon.stub().returns("Pig farm!")
+	};
+	const res = middlewareUtil.getProject(mockResource);
+
+	t.is(getProjectStub.callCount, 0, "ProjectGraph#getProject never got called");
+	t.is(mockResource.getProject.callCount, 1, "Resource#getProject got called once");
+	t.is(res, "Pig farm!", "Correct result");
 });
 
 test("getDependencies", (t) => {


### PR DESCRIPTION
For custom middleware this will returned a Specification
Version-dependent (=compatible) interface of the Project instance a
Resource is associated with.

This was already described in RFC12[1] but not part of the initial
implementation of MiddlewareUtil#getProject.

[1] https://github.com/SAP/ui5-tooling/pull/664