### PR TITLE
[INTERNAL] Refactor log-calls

### DIFF
--- a/lib/middleware/MiddlewareManager.js
+++ b/lib/middleware/MiddlewareManager.js
@@ -300,7 +300,7 @@ class MiddlewareManager {
 					const specVersion = customMiddleware.getSpecVersion();
 					if (specVersion.gte("3.0")) {
 						params.options.middlewareName = middlewareName;
-						params.log = logger.getGroupLogger(`server:custom-middleware:${middlewareDef.name}`);
+						params.log = logger.getLogger(`server:custom-middleware:${middlewareDef.name}`);
 					}
 					const middlewareUtilInterface = middlewareUtil.getInterface(specVersion);
 					if (middlewareUtilInterface) {

--- a/lib/middleware/serveResources.js
+++ b/lib/middleware/serveResources.js
@@ -84,7 +84,7 @@ function createMiddleware({resources, middlewareUtil}) {
 					stream.setEncoding("utf8");
 					stream = stream.pipe(replaceStream("${version}", resource.getProject().getVersion()));
 				} else {
-					log.verbose("Project missing from resource %s", pathname);
+					log.verbose(`Project missing from resource ${pathname}"`);
 				}
 			}
 

--- a/test/lib/server/middleware/MiddlewareManager.js
+++ b/test/lib/server/middleware/MiddlewareManager.js
@@ -8,7 +8,7 @@ test.beforeEach(async (t) => {
 	const sinon = t.context.sinon = sinonGlobal.createSandbox();
 
 	t.context.logger = {
-		getGroupLogger: sinon.stub().returns("group logger")
+		getLogger: sinon.stub().returns("group logger")
 	};
 
 	t.context.MiddlewareManager = await esmock("../../../../lib/middleware/MiddlewareManager.js", {
@@ -176,7 +176,7 @@ test("addMiddleware: Add middleware with beforeMiddleware=connectUi5Proxy", asyn
 	const {sinon} = t.context;
 	const warnSpy = sinon.spy();
 	const StubbedMiddlewareManager = await esmock("../../../../lib/middleware/MiddlewareManager.js", {
-		"@ui5/logger": {getGroupLogger: sinon.stub().returns({warn: warnSpy})}
+		"@ui5/logger": {getLogger: sinon.stub().returns({warn: warnSpy})}
 	});
 	const middlewareManager = new StubbedMiddlewareManager({
 		graph: {},


### PR DESCRIPTION
Use template literals instead of placeholders.

This is in prepration for @ui5/logger changes as per
https://github.com/SAP/ui5-logger/pull/353