### PR TITLE
[INTERNAL] serveIndex: Fix Resource attribute access

### DIFF
--- a/lib/middleware/serveIndex.js
+++ b/lib/middleware/serveIndex.js
@@ -49,7 +49,7 @@ function createResourceInfo(resource) {
 	const isDir = stat.isDirectory();
 	return {
 		path: resource.getPath() + (isDir ? "/" : ""),
-		name: resource._name + (isDir ? "/" : ""),
+		name: resource.getName() + (isDir ? "/" : ""),
 		isDir: isDir,
 		mimetype: isDir ? "" : getMimeType(resource),
 		lastModified: new Date(stat.mtime).toLocaleString(),


### PR DESCRIPTION
`_name` attribute got removed in https://github.com/SAP/ui5-fs/pull/472

This is now breaking tests