### PR TITLE
[FIX] MiddlewareUtil: Provide framework configuration getters to custom tasks

### DIFF
--- a/lib/middleware/MiddlewareUtil.js
+++ b/lib/middleware/MiddlewareUtil.js
@@ -239,7 +239,7 @@ class MiddlewareUtil {
 				// the /resources/<namespace> path prefix is omitted for "runtime". Also, no builder resource-
 				// exclude configuration is applied.
 				// Therefore default to style "runtime" here so that custom middleware will commonly work with
-				//  the same paths as ui5-server and no unexpected builder-excludes.
+				// the same paths as ui5-server and no unexpected builder-excludes.
 				baseProjectInterface.getReader = function(options = {style: "runtime"}) {
 					return project.getReader(options);
 				};

--- a/lib/middleware/MiddlewareUtil.js
+++ b/lib/middleware/MiddlewareUtil.js
@@ -112,9 +112,9 @@ class MiddlewareUtil {
 	 * @property {Function} getSourcePath Get the local File System path of the project's source directory
 	 * @property {Function} getCustomConfiguration Get the project Custom Configuration
 	 * @property {Function} isFrameworkProject Check whether the project is a UI5-Framework project
-	 * @property {Function} getFrameworkName Get the project's frameworkName configuration
-	 * @property {Function} getFrameworkVersion Get the project's frameworkVersion configuration
-	 * @property {Function} getFrameworkDependencies Get the project's frameworkDependencies configuration
+	 * @property {Function} getFrameworkName Get the project's framework name configuration
+	 * @property {Function} getFrameworkVersion Get the project's framework version configuration
+	 * @property {Function} getFrameworkDependencies Get the project's framework dependencies configuration
 	 */
 
 	/**

--- a/lib/middleware/MiddlewareUtil.js
+++ b/lib/middleware/MiddlewareUtil.js
@@ -107,11 +107,14 @@ class MiddlewareUtil {
 	 * @property {Function} getVersion Get the project version
 	 * @property {Function} getNamespace Get the project namespace
 	 * @property {Function} getRootReader Get the project rootReader
-	 * @property {Function} getReader Get the project reader
+	 * @property {Function} getReader Get the project reader, defaulting to "runtime" style instead of "buildtime"
 	 * @property {Function} getRootPath Get the local File System path of the project's root directory
 	 * @property {Function} getSourcePath Get the local File System path of the project's source directory
 	 * @property {Function} getCustomConfiguration Get the project Custom Configuration
 	 * @property {Function} isFrameworkProject Check whether the project is a UI5-Framework project
+	 * @property {Function} getFrameworkName Get the project's frameworkName configuration
+	 * @property {Function} getFrameworkVersion Get the project's frameworkVersion configuration
+	 * @property {Function} getFrameworkDependencies Get the project's frameworkDependencies configuration
 	 */
 
 	/**
@@ -227,9 +230,19 @@ class MiddlewareUtil {
 				const baseProjectInterface = {};
 				bindFunctions(project, baseProjectInterface, [
 					"getType", "getName", "getVersion", "getNamespace",
-					"getRootReader", "getReader", "getRootPath", "getSourcePath",
-					"getCustomConfiguration", "isFrameworkProject"
+					"getRootReader", "getRootPath", "getSourcePath",
+					"getCustomConfiguration", "isFrameworkProject", "getFrameworkName",
+					"getFrameworkVersion", "getFrameworkDependencies"
 				]);
+				// Project#getReader defaults to style "buildtime". However ui5-server uses
+				// style "runtime". The main difference is that for some project types (like applications)
+				// the /resources/<namespace> path prefix is omitted for "runtime". Also, no builder resource-
+				// exclude configuration is applied.
+				// Therefore default to style "runtime" here so that custom middleware will commonly work with
+				//  the same paths as ui5-server and no unexpected builder-excludes.
+				baseProjectInterface.getReader = function(options = {style: "runtime"}) {
+					return project.getReader(options);
+				};
 				return baseProjectInterface;
 			};
 			// getDependencies function, returning an array of project names

--- a/test/lib/server/middleware/MiddlewareUtil.js
+++ b/test/lib/server/middleware/MiddlewareUtil.js
@@ -278,6 +278,7 @@ test("getInterface: specVersion 2.6", (t) => {
 });
 
 test("getInterface: specVersion 3.0", (t) => {
+	const getReaderStub = sinon.stub().returns("reader");
 	const getProjectStub = sinon.stub().returns({
 		getSpecVersion: () => "specVersion",
 		getType: () => "type",
@@ -286,12 +287,14 @@ test("getInterface: specVersion 3.0", (t) => {
 		getNamespace: () => "namespace",
 		getRootReader: () => "rootReader",
 		getRootPath: () => "rootPath",
-		getReader: () => "reader",
+		getReader: getReaderStub,
 		getSourcePath: () => "sourcePath",
 		getCustomConfiguration: () => "customConfiguration",
 		isFrameworkProject: () => "isFrameworkProject",
+		getFrameworkVersion: () => "frameworkVersion",
+		getFrameworkName: () => "frameworkName",
+		getFrameworkDependencies: () => ["frameworkDependencies"],
 		hasBuildManifest: () => "hasBuildManifest", // Should not be exposed
-		getFrameworkVersion: () => "frameworkVersion", // Should not be exposed
 	});
 	const getDependenciesStub = sinon.stub().returns(["dep a", "dep b"]);
 
@@ -325,11 +328,14 @@ test("getInterface: specVersion 3.0", (t) => {
 		"getVersion",
 		"getNamespace",
 		"getRootReader",
-		"getReader",
 		"getRootPath",
 		"getSourcePath",
 		"getCustomConfiguration",
 		"isFrameworkProject",
+		"getFrameworkName",
+		"getFrameworkVersion",
+		"getFrameworkDependencies",
+		"getReader",
 	], "Correct methods are provided");
 
 	t.is(interfacedProject.getType(), "type", "getType function is bound correctly");
@@ -339,11 +345,20 @@ test("getInterface: specVersion 3.0", (t) => {
 	t.is(interfacedProject.getRootReader(), "rootReader", "getRootReader function is bound correctly");
 	t.is(interfacedProject.getRootPath(), "rootPath", "getRootPath function is bound correctly");
 	t.is(interfacedProject.getReader(), "reader", "getReader function is bound correctly");
+	t.is(getReaderStub.callCount, 1, "Project#getReader stub got called once");
+	t.deepEqual(getReaderStub.firstCall.firstArg, {style: "runtime"},
+		"Project#getReader got called with expected style parameter");
 	t.is(interfacedProject.getSourcePath(), "sourcePath", "getSourcePath function is bound correctly");
 	t.is(interfacedProject.getCustomConfiguration(), "customConfiguration",
 		"getCustomConfiguration function is bound correctly");
 	t.is(interfacedProject.isFrameworkProject(), "isFrameworkProject",
 		"isFrameworkProject function is bound correctly");
+	t.is(interfacedProject.getFrameworkVersion(), "frameworkVersion",
+		"getFrameworkVersion function is bound correctly");
+	t.is(interfacedProject.getFrameworkName(), "frameworkName",
+		"getFrameworkName function is bound correctly");
+	t.deepEqual(interfacedProject.getFrameworkDependencies(), ["frameworkDependencies"],
+		"getFrameworkDependencies function is bound correctly");
 
 	// getDependencies
 	t.deepEqual(interfacedMiddlewareUtil.getDependencies("pony"), ["dep a", "dep b"],


### PR DESCRIPTION
This was missed to add to the initial 3.0.0 release.
Also see https://github.com/SAP/ui5-project/pull/580

Additionally, for the Project#getReader function, default the 'style'
parameter to 'runtime'. We expect this match best with custom middleware
expectations, since ui5-server itself uses the same style.