### PR TITLE
[BREAKING] Replace console.log with process.stderr 

### DIFF
--- a/lib/sslUtil.js
+++ b/lib/sslUtil.js
@@ -71,12 +71,14 @@ async function createAndInstallCertificate(keyPath, certPath) {
 	// TODO: Prompt and logging should happen in CLI module rather than server
 	if (process.platform === "win32") {
 		/* eslint-disable-next-line no-console */
-		console.log("Please press allow in the opened dialog to confirm importing the newly created " +
+		process.stderr.write("Please press allow in the opened dialog to confirm importing the newly created " +
 			"SSL certificate into the operating system and browsers.");
+		process.stderr.write("\n");
 	} else {
 		/* eslint-disable-next-line no-console */
-		console.log("Please enter your root password to allow importing the newly created " +
+		process.stderr.write("Please enter your root password to allow importing the newly created " +
 			"SSL certificate into the operating system and browsers.");
+		process.stderr.write("\n");
 	}
 
 	const {key, cert} = await devCert("UI5Tooling");

--- a/lib/sslUtil.js
+++ b/lib/sslUtil.js
@@ -70,12 +70,10 @@ async function createAndInstallCertificate(keyPath, certPath) {
 	// the created certificate into the system)
 	// TODO: Prompt and logging should happen in CLI module rather than server
 	if (process.platform === "win32") {
-		/* eslint-disable-next-line no-console */
 		process.stderr.write("Please press allow in the opened dialog to confirm importing the newly created " +
 			"SSL certificate into the operating system and browsers.");
 		process.stderr.write("\n");
 	} else {
-		/* eslint-disable-next-line no-console */
 		process.stderr.write("Please enter your root password to allow importing the newly created " +
 			"SSL certificate into the operating system and browsers.");
 		process.stderr.write("\n");


### PR DESCRIPTION
BREAKING CHANGE:
Messages will now be written to stderr instead of stdout.

JIRA: CPOUI5FOUNDATION-802
Related to: https://github.com/SAP/ui5-tooling/issues/701
Sibling of: https://github.com/SAP/ui5-tooling/pull/930, https://github.com/SAP/ui5-cli/pull/686