### PR TITLE
[INTERNAL] serveResources: Dynamically generate missing library manifest.json

### DIFF
--- a/lib/middleware/MiddlewareManager.js
+++ b/lib/middleware/MiddlewareManager.js
@@ -220,16 +220,7 @@ class MiddlewareManager {
 		await this.addMiddleware("testRunner");
 		await this.addMiddleware("serveThemes");
 		await this.addMiddleware("versionInfo", {
-			mountPath: "/resources/sap-ui-version.json",
-			wrapperCallback: ({middleware: versionInfoModule}) => {
-				return ({resources, middlewareUtil}) => {
-					return versionInfoModule({
-						resources,
-						middlewareUtil,
-						graph: this.graph
-					});
-				};
-			}
+			mountPath: "/resources/sap-ui-version.json"
 		});
 		// Handle anything but read operations *before* the serveIndex middleware
 		//	as it will reject them with a 405 (Method not allowed) instead of 404 like our old tooling

--- a/lib/middleware/helper/generateLibraryManifest.js
+++ b/lib/middleware/helper/generateLibraryManifest.js
@@ -9,9 +9,6 @@ export default async function generateLibraryManifest(middlewareUtil, dotLibReso
 		libraryResource: dotLibResource,
 		namespace: project.getNamespace(),
 		resources: libResources,
-		options: {
-			omitMinVersions: true
-		},
 		getProjectVersion: (projectName) => {
 			return middlewareUtil.getProject(projectName)?.getVersion();
 		}

--- a/lib/middleware/helper/generateLibraryManifest.js
+++ b/lib/middleware/helper/generateLibraryManifest.js
@@ -1,0 +1,21 @@
+import createManifestProcessor from "@ui5/builder/processors/manifestCreator";
+
+export default async function generateLibraryManifest(middlewareUtil, dotLibResource) {
+	const project = dotLibResource.getProject();
+	const libResources = await project.getReader().byGlob(
+		`/resources/**/*.{js,json,library,less,css,theming,theme,properties}`);
+
+	const res = await createManifestProcessor({
+		libraryResource: dotLibResource,
+		namespace: project.getNamespace(),
+		resources: libResources,
+		options: {
+			omitMinVersions: true
+		},
+		getProjectVersion: (projectName) => {
+			return middlewareUtil.getProject(projectName)?.getVersion();
+		}
+	});
+	res.setProject(project);
+	return res;
+}

--- a/lib/middleware/serveResources.js
+++ b/lib/middleware/serveResources.js
@@ -7,7 +7,7 @@ import fresh from "fresh";
 const rProperties = /\.properties$/i;
 const rReplaceVersion = /\.(library|js|json)$/i;
 const rManifest = /\/manifest.json$/i;
-const rResourcesPrefix = /^\/resources/i;
+const rResourcesPrefix = /^\/resources\//i;
 
 function isFresh(req, res) {
 	return fresh(req.headers, {
@@ -113,7 +113,6 @@ function createMiddleware({resources, middlewareUtil}) {
 
 			stream.pipe(res);
 		} catch (err) {
-			console.log(err.stack);
 			next(err);
 		}
 	};

--- a/lib/middleware/serveResources.js
+++ b/lib/middleware/serveResources.js
@@ -6,6 +6,8 @@ import fresh from "fresh";
 
 const rProperties = /\.properties$/i;
 const rReplaceVersion = /\.(library|js|json)$/i;
+const rManifest = /\/manifest.json$/i;
+const rResourcesPrefix = /^\/resources/i;
 
 function isFresh(req, res) {
 	return fresh(req.headers, {
@@ -20,18 +22,33 @@ function isFresh(req, res) {
  * @module @ui5/server/middleware/serveResources
  * @param {object} parameters Parameters
  * @param {@ui5/server/internal/MiddlewareManager.middlewareResources} parameters.resources Parameters
- * @param {object} parameters.middlewareUtil Specification version dependent interface to a
- *                                        [MiddlewareUtil]{@link @ui5/server/middleware/MiddlewareUtil} instance
+ * @param {object} parameters.middlewareUtil [MiddlewareUtil]{@link @ui5/server/middleware/MiddlewareUtil} instance
  * @returns {Function} Returns a server middleware closure.
  */
 function createMiddleware({resources, middlewareUtil}) {
 	return async function serveResources(req, res, next) {
 		try {
 			const pathname = middlewareUtil.getPathname(req);
-			const resource = await resources.all.byPath(pathname);
+			let resource = await resources.all.byPath(pathname);
 			if (!resource) { // Not found
-				next();
-				return;
+				if (!rManifest.test(pathname) || !rResourcesPrefix.test(pathname)) {
+					next();
+					return;
+				}
+				log.verbose(`Could not find manifest.json for ${pathname}. ` +
+					`Checking for .library file to generate manifest.json from.`);
+				const {default: generateLibraryManifest} = await import("./helper/generateLibraryManifest.js");
+				// Attempt to find a .library file, which is required for generating a manifest.json
+				const dotLibraryPath = pathname.replace(rManifest, "/.library");
+				const dotLibraryResource = await resources.all.byPath(dotLibraryPath);
+				if (!dotLibraryResource) {
+					log.verbose(
+						`Could not find a .library to generate manifest.json from at ${dotLibraryPath}. ` +
+						`This might indicate that the project is not a library project.`);
+					next();
+					return;
+				}
+				resource = await generateLibraryManifest(middlewareUtil, dotLibraryResource);
 			}
 
 			const resourcePath = resource.getPath();
@@ -64,7 +81,13 @@ function createMiddleware({resources, middlewareUtil}) {
 			}
 
 			// Enable ETag caching
-			res.setHeader("ETag", etag(resource.getStatInfo()));
+			const statInfo = resource.getStatInfo();
+			if (statInfo?.size !== undefined) {
+				res.setHeader("ETag", etag(statInfo));
+			} else {
+				// Fallback to buffer if stats are not available or insufficient
+				res.setHeader("ETag", etag(await resource.getBuffer()));
+			}
 
 			if (isFresh(req, res)) {
 				// client has a fresh copy of the resource
@@ -90,6 +113,7 @@ function createMiddleware({resources, middlewareUtil}) {
 
 			stream.pipe(res);
 		} catch (err) {
+			console.log(err.stack);
 			next(err);
 		}
 	};

--- a/lib/middleware/versionInfo.js
+++ b/lib/middleware/versionInfo.js
@@ -1,5 +1,5 @@
 import createVersionInfoProcessor from "@ui5/builder/processors/versionInfoGenerator";
-import createManifestProcessor from "@ui5/builder/processors/manifestCreator";
+import generateLibraryManifest from "./helper/generateLibraryManifest.js";
 
 const MANIFEST_JSON = "manifest.json";
 
@@ -9,10 +9,10 @@ const MANIFEST_JSON = "manifest.json";
  * @module @ui5/server/middleware/versionInfo
  * @param {object} parameters Parameters
  * @param {@ui5/server/internal/MiddlewareManager.middlewareResources} parameters.resources Parameters
- * @param {@ui5/project/graph/ProjectGraph} parameters.graph Project graph
+ * @param {object} parameters.middlewareUtil [MiddlewareUtil]{@link @ui5/server/middleware/MiddlewareUtil} instance
  * @returns {Function} Returns a server middleware closure.
  */
-function createMiddleware({resources, graph}) {
+function createMiddleware({resources, middlewareUtil}) {
 	return async function versionInfo(req, res, next) {
 		try {
 			const dependencies = resources.dependencies;
@@ -31,20 +31,7 @@ function createMiddleware({resources, graph}) {
 				const embeddedManifests =
 					manifestResources.filter((manifestResource) => manifestResource !== libraryManifest);
 				if (!libraryManifest) {
-					const extensions = "js,json,library,less,css,theming,theme,properties";
-					const libResources = await dependencies.byGlob(`/resources/${namespace}/**/*.{${extensions}}`);
-
-					libraryManifest = await createManifestProcessor({
-						libraryResource: dotLibResource,
-						namespace,
-						resources: libResources,
-						options: {
-							omitMinVersions: true
-						},
-						getProjectVersion: (projectName) => {
-							return graph.getProject(projectName)?.getVersion();
-						}
-					});
+					libraryManifest = await generateLibraryManifest(middlewareUtil, dotLibResource);
 				}
 				return {
 					libraryManifest,
@@ -53,7 +40,7 @@ function createMiddleware({resources, graph}) {
 					version: dotLibResource.getProject().getVersion()
 				};
 			});
-			const rootProject = graph.getRoot();
+			const rootProject = middlewareUtil.getProject();
 			const libraryInfos = await Promise.all(libraryInfosPromises);
 			const [versionInfoResource] = await createVersionInfoProcessor({
 				options: {

--- a/test/lib/server/middleware/helper/generateLibraryManifest.js
+++ b/test/lib/server/middleware/helper/generateLibraryManifest.js
@@ -61,7 +61,7 @@ test("Generate library manifest", async (t) => {
 		{
 			"dependencies":
 			{
-				"minUI5Version": "",
+				"minUI5Version": "1.0",
 				"libs":
 				{}
 			},

--- a/test/lib/server/middleware/helper/generateLibraryManifest.js
+++ b/test/lib/server/middleware/helper/generateLibraryManifest.js
@@ -1,0 +1,74 @@
+import test from "ava";
+import {createResource, createAdapter} from "@ui5/fs/resourceFactory";
+import generateLibraryManifest from "../../../../../lib/middleware/helper/generateLibraryManifest.js";
+
+test("Generate library manifest", async (t) => {
+	const reader = createAdapter({
+		virBasePath: "/"
+	});
+	const project = {
+		getNamespace: () => "sap/foo",
+		getVersion: () => "1.0.0",
+		getReader: () => reader
+	};
+	const middlewareUtilMock = {
+		getProject: () => project
+	};
+	const dotLibResource = createResource({
+		path: "/resources/sap/foo/.library",
+		string: `<?xml version="1.0" encoding="UTF-8" ?>
+<library xmlns="http://www.sap.com/sap.ui.library.xsd" >
+
+	<name>library.e</name>
+	<vendor>SAP SE</vendor>
+	<copyright>\${copyright}</copyright>
+	<version>\${version}</version>
+
+	<documentation>Library E</documentation>
+
+</library>
+`, project,
+	});
+
+	const res = await generateLibraryManifest(middlewareUtilMock, dotLibResource);
+	t.is(res.getPath(), "/resources/sap/foo/manifest.json", "Created manifest.json has expected path");
+	t.deepEqual(JSON.parse(await res.getString()), {
+		"_version": "1.21.0",
+		"sap.app":
+		{
+			"id": "library.e",
+			"type": "library",
+			"embeds":
+			[],
+			"applicationVersion":
+			{
+				"version": "1.0.0"
+			},
+			"title": "Library E",
+			"description": "Library E",
+			"resources": "resources.json",
+			"offline": true
+		},
+		"sap.ui":
+		{
+			"technology": "UI5",
+			"supportedThemes":
+			[]
+		},
+		"sap.ui5":
+		{
+			"dependencies":
+			{
+				"minUI5Version": "",
+				"libs":
+				{}
+			},
+			"library":
+			{
+				"i18n": false
+			}
+		}
+	}, "Created manifest.json has expected content");
+	t.is(res.getProject(), project, "Created manifest.json has expected project set");
+});
+

--- a/test/lib/server/middleware/versionInfo.js
+++ b/test/lib/server/middleware/versionInfo.js
@@ -228,6 +228,12 @@ test.serial("test all inner API calls within middleware", async (t) => {
 		});
 
 	t.is(manifestCreatorStub.callCount, 2);
+	t.deepEqual(Object.keys(manifestCreatorStub.getCall(0).args[0]), [
+		"libraryResource",
+		"namespace",
+		"resources",
+		"getProjectVersion"
+	], "Expected arguments provided");
 	t.is(manifestCreatorStub.getCall(0).args[0].libraryResource.getPath(), "/resources/lib/a/.library");
 	t.is(manifestCreatorStub.getCall(1).args[0].libraryResource.getPath(), "/resources/lib/c/.library");
 	t.is(manifestCreatorStub.getCall(0).args[0].namespace, "lib/a");
@@ -247,8 +253,6 @@ test.serial("test all inner API calls within middleware", async (t) => {
 			"/resources/lib/c/foo.theme",
 			"/resources/lib/c/foo.theming"
 		]);
-	t.deepEqual(manifestCreatorStub.getCall(0).args[0].options, {omitMinVersions: true});
-	t.deepEqual(manifestCreatorStub.getCall(1).args[0].options, {omitMinVersions: true});
 	const projectVersion1 = manifestCreatorStub.getCall(0).args[0].getProjectVersion("my.project");
 	t.is(projectVersion1, "project version", "getProjectVersion callback returned expected project version");
 	const projectVersion2 = manifestCreatorStub.getCall(1).args[0].getProjectVersion("my.other.project");


### PR DESCRIPTION
UI5 libraries (especially framework libraries) often lack a manifest.json in their source. However some UI5 runtime API requires a manifest.json to function properly. For example to locate i18n resources at a non-default location.

With this change, the serveResources middleware will attempt to generate missing manifest.json files on-the-fly. This mimics the behavior of the ui5-builder's generateLibraryManifest task and the result is almost identical.

JIRA: CPOUI5FOUNDATION-688