### PR TITLE
[INTERNAL] middleware/versionInfo: Only process dependencies of type 'library'

### DIFF
--- a/lib/middleware/helper/generateLibraryManifest.js
+++ b/lib/middleware/helper/generateLibraryManifest.js
@@ -13,6 +13,8 @@ export default async function generateLibraryManifest(middlewareUtil, dotLibReso
 			return middlewareUtil.getProject(projectName)?.getVersion();
 		}
 	});
-	res.setProject(project);
-	return res;
+	if (res) {
+		res.setProject(project);
+		return res;
+	}
 }

--- a/lib/middleware/serveResources.js
+++ b/lib/middleware/serveResources.js
@@ -41,14 +41,14 @@ function createMiddleware({resources, middlewareUtil}) {
 				// Attempt to find a .library file, which is required for generating a manifest.json
 				const dotLibraryPath = pathname.replace(rManifest, "/.library");
 				const dotLibraryResource = await resources.all.byPath(dotLibraryPath);
-				if (!dotLibraryResource) {
-					log.verbose(
-						`Could not find a .library to generate manifest.json from at ${dotLibraryPath}. ` +
-						`This might indicate that the project is not a library project.`);
+				if (dotLibraryResource && dotLibraryResource.getProject()?.getType() === "library") {
+					resource = await generateLibraryManifest(middlewareUtil, dotLibraryResource);
+				}
+				if (!resource) {
+					// Not a library project, missing .library file or other reason for failed manifest.json generation
 					next();
 					return;
 				}
-				resource = await generateLibraryManifest(middlewareUtil, dotLibraryResource);
 			}
 
 			const resourcePath = resource.getPath();

--- a/lib/middleware/versionInfo.js
+++ b/lib/middleware/versionInfo.js
@@ -16,7 +16,9 @@ function createMiddleware({resources, middlewareUtil}) {
 	return async function versionInfo(req, res, next) {
 		try {
 			const dependencies = resources.dependencies;
-			const dotLibResources = await dependencies.byGlob("/resources/**/.library");
+			let dotLibResources = await dependencies.byGlob("/resources/**/.library");
+
+			dotLibResources = dotLibResources.filter((res) => res.getProject()?.getType() === "library");
 
 			dotLibResources.sort((a, b) => {
 				return a.getProject().getName().localeCompare(b.getProject().getName());


### PR DESCRIPTION
Ignore any other project types, even if the project contains a .library
file.

Some projects might consume UI5 libraries configured as type "module".
In order to align the ui5-server's behavior with the ui5-builder, those
projects must be ignored when generating the sap-ui-version.json.

For the same reason the serveResources middleware must not attempt to
generate a missing manifest.json for such projects.

(cherry picked from commit f0283ed7b20eff73516d354017233d9b57cf5535)