### PR TITLE
[INTERNAL] package.json: Allow npm >= v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
 			},
 			"engines": {
 				"node": "^20.11.0 || >=21.2.0",
-				"npm": ">= 10"
+				"npm": ">= 8"
 			}
 		},
 		"node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	},
 	"engines": {
 		"node": "^20.11.0 || >=21.2.0",
-		"npm": ">= 10"
+		"npm": ">= 8"
 	},
 	"scripts": {
 		"test": "npm run lint && npm run jsdoc-generate && npm run coverage && npm run depcheck",


### PR DESCRIPTION
There is no actual need to increase the minimum npm version. Lockfile v3 is already supported