### PR TITLE
[INTERNAL] Pin eslint-plugin-jsdoc to 61.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
 				"eslint": "^9.39.2",
 				"eslint-config-google": "^0.14.0",
 				"eslint-plugin-ava": "^15.1.0",
-				"eslint-plugin-jsdoc": "^60.8.3",
+				"eslint-plugin-jsdoc": "61.5.0",
 				"esmock": "^2.7.3",
 				"globals": "^16.5.0",
 				"jsdoc": "^4.0.5",
@@ -509,9 +509,9 @@
 			}
 		},
 		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.71.0",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.71.0.tgz",
-			"integrity": "sha512-2p9+dXWNQnp5Kq/V0XVWZiVAabzlX6rUW8vXXvtX8Yc1CkKgD93IPDEnv1sYZFkkS6HMvg6H0RMZfob/Co0YXA==",
+			"version": "0.76.0",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.76.0.tgz",
+			"integrity": "sha512-g+RihtzFgGTx2WYCuTHbdOXJeAlGnROws0TeALx9ow/ZmOROOZkVg5wp/B44n0WJgI4SQFP1eWM2iRPlU2Y14w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -519,10 +519,20 @@
 				"@typescript-eslint/types": "^8.46.0",
 				"comment-parser": "1.4.1",
 				"esquery": "^1.6.0",
-				"jsdoc-type-pratt-parser": "~6.6.0"
+				"jsdoc-type-pratt-parser": "~6.10.0"
 			},
 			"engines": {
 				"node": ">=20.11.0"
+			}
+		},
+		"node_modules/@es-joy/resolve.exports": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+			"integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -1447,6 +1457,19 @@
 			},
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/@sindresorhus/base62": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+			"integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@sindresorhus/merge-streams": {
@@ -4478,13 +4501,14 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "60.8.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-60.8.3.tgz",
-			"integrity": "sha512-4191bTMvnd5WUtopCdzNhQchvv/MxtPD86ZGl3vem8Ibm22xJhKuIyClmgSxw+YERtorVc/NhG+bGjfFVa6+VQ==",
+			"version": "61.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-61.5.0.tgz",
+			"integrity": "sha512-PR81eOGq4S7diVnV9xzFSBE4CDENRQGP0Lckkek8AdHtbj+6Bm0cItwlFnxsLFriJHspiE3mpu8U20eODyToIg==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.71.0",
+				"@es-joy/jsdoccomment": "~0.76.0",
+				"@es-joy/resolve.exports": "1.2.0",
 				"are-docs-informative": "^0.0.2",
 				"comment-parser": "1.4.1",
 				"debug": "^4.4.3",
@@ -4492,10 +4516,11 @@
 				"espree": "^10.4.0",
 				"esquery": "^1.6.0",
 				"html-entities": "^2.6.0",
-				"object-deep-merge": "^1.0.5",
+				"object-deep-merge": "^2.0.0",
 				"parse-imports-exports": "^0.2.4",
-				"semver": "^7.7.2",
-				"spdx-expression-parse": "^4.0.0"
+				"semver": "^7.7.3",
+				"spdx-expression-parse": "^4.0.0",
+				"to-valid-identifier": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=20.11.0"
@@ -6670,9 +6695,9 @@
 			}
 		},
 		"node_modules/jsdoc-type-pratt-parser": {
-			"version": "6.6.0",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-6.6.0.tgz",
-			"integrity": "sha512-3hSD14nXx66Rspx1RMnz1Pj4JacrMBAsC0CrF9lZYO/Qsp5/oIr6KqujVUNhQu94B6mMip2ukki8MpEWZwyhKA==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-6.10.0.tgz",
+			"integrity": "sha512-+LexoTRyYui5iOhJGn13N9ZazL23nAHGkXsa1p/C8yeq79WRfLBag6ZZ0FQG2aRoc9yfo59JT9EYCQonOkHKkQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8135,27 +8160,11 @@
 			}
 		},
 		"node_modules/object-deep-merge": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-1.0.5.tgz",
-			"integrity": "sha512-3DioFgOzetbxbeUq8pB2NunXo8V0n4EvqsWM/cJoI6IA9zghd7cl/2pBOuWRf4dlvA+fcg5ugFMZaN2/RuoaGg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.0.tgz",
+			"integrity": "sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"type-fest": "4.2.0"
-			}
-		},
-		"node_modules/object-deep-merge/node_modules/type-fest": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.2.0.tgz",
-			"integrity": "sha512-5zknd7Dss75pMSED270A1RQS3KloqRJA9XbXLe0eCxyw7xXFb3rd+9B0UQ/0E+LQT6lnrLviEolYORlRWamn4w==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
+			"license": "MIT"
 		},
 		"node_modules/object-inspect": {
 			"version": "1.13.4",
@@ -9339,6 +9348,19 @@
 			"license": "MIT",
 			"dependencies": {
 				"lodash": "^4.17.21"
+			}
+		},
+		"node_modules/reserved-identifiers": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+			"integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/resolve": {
@@ -10777,6 +10799,23 @@
 			},
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/to-valid-identifier": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+			"integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/base62": "^1.0.0",
+				"reserved-identifiers": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
 		"eslint": "^9.39.2",
 		"eslint-config-google": "^0.14.0",
 		"eslint-plugin-ava": "^15.1.0",
-		"eslint-plugin-jsdoc": "^60.8.3",
+		"eslint-plugin-jsdoc": "61.5.0",
 		"esmock": "^2.7.3",
 		"globals": "^16.5.0",
 		"jsdoc": "^4.0.5",


### PR DESCRIPTION
Higher versions require a slightly higher Node.js version (20.19.0) than currently required by this project (20.11.0)
