### PR TITLE
[INTERNAL] Replace depcheck with knip

### DIFF
--- a/knip.config.js
+++ b/knip.config.js
@@ -18,10 +18,9 @@ const config = {
 	ignoreDependencies: [
 		"@istanbuljs/esm-loader-hook",
 		"docdash",
-		"jsdoc",
 		"compression",
 		"cors"
-	],
+	]
 };
 
 export default config;

--- a/knip.config.js
+++ b/knip.config.js
@@ -16,8 +16,22 @@ const config = {
 	},
 
 	ignoreDependencies: [
+		/**
+		 * Used via nyc ava --node-arguments="--experimental-loader=@istanbuljs/esm-loader-hook"
+		 * which is not detected by knip as a usage of this package
+		 */
 		"@istanbuljs/esm-loader-hook",
+
+		/**
+		 * Used as jsdoc template in package.json script, which is not detected
+		 */
 		"docdash",
+
+		/**
+		 * We ignore these dependencies here because these are dynamic imports
+		 * and knip is unable to detect that these are being used
+		 * (See packages/server/lib/middleware/MiddlewareManager.js)
+		 */
 		"compression",
 		"cors"
 	]

--- a/knip.config.js
+++ b/knip.config.js
@@ -30,7 +30,7 @@ const config = {
 		/**
 		 * We ignore these dependencies here because these are dynamic imports
 		 * and knip is unable to detect that these are being used
-		 * (See packages/server/lib/middleware/MiddlewareManager.js)
+		 * (lib/middleware/MiddlewareManager.js)
 		 */
 		"compression",
 		"cors"

--- a/knip.config.js
+++ b/knip.config.js
@@ -1,0 +1,27 @@
+const config = {
+	/**
+	 * As we currently only need unused dependency checks, we disable all checks except for that
+	 */
+	rules: {
+		files: "off",
+		duplicates: "off",
+		classMembers: "off",
+		unlisted: "off",
+		binaries: "off",
+		unresolved: "off",
+		catalog: "off",
+		exports: "off",
+		types: "off",
+		enumMembers: "off",
+	},
+
+	ignoreDependencies: [
+		"@istanbuljs/esm-loader-hook",
+		"docdash",
+		"jsdoc",
+		"compression",
+		"cors"
+	],
+};
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
 				"ava": "^6.4.1",
 				"chokidar-cli": "^3.0.0",
 				"cross-env": "^10.1.0",
-				"depcheck": "^1.4.7",
 				"docdash": "^2.0.2",
 				"eslint": "^9.39.2",
 				"eslint-config-google": "^0.14.0",
@@ -45,6 +44,7 @@
 				"esmock": "^2.7.3",
 				"globals": "^16.5.0",
 				"jsdoc": "^4.0.5",
+				"knip": "^5.83.1",
 				"nyc": "^17.1.0",
 				"open-cli": "^8.0.0",
 				"rimraf": "^6.1.2",
@@ -506,6 +506,40 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+			"integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.1.0",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+			"integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+			"integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@epic-web/invariant": {
@@ -1020,6 +1054,23 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+			"integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1",
+				"@tybys/wasm-util": "^0.10.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
 		"node_modules/@noble/hashes": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -1343,6 +1394,289 @@
 				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
+		"node_modules/@oxc-resolver/binding-android-arm-eabi": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.17.1.tgz",
+			"integrity": "sha512-+VuZyMYYaap5uDAU1xDU3Kul0FekLqpBS8kI5JozlWfYQKnc/HsZg2gHPkQrj0SC9lt74WMNCfOzZZJlYXSdEQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-android-arm64": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.17.1.tgz",
+			"integrity": "sha512-YlDDTjvOEKhom/cRSVsXsMVeXVIAM9PJ/x2mfe08rfuS0iIEfJd8PngKbEIhG72WPxleUa+vkEZj9ncmC14z3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-darwin-arm64": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.17.1.tgz",
+			"integrity": "sha512-HOYYLSY4JDk14YkXaz/ApgJYhgDP4KsG8EZpgpOxdszGW9HmIMMY/vXqVKYW74dSH+GQkIXYxBrEh3nv+XODVg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-darwin-x64": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.17.1.tgz",
+			"integrity": "sha512-JHPJbsa5HvPq2/RIdtGlqfaG9zV2WmgvHrKTYmlW0L5esqtKCBuetFudXTBzkNcyD69kSZLzH92AzTr6vFHMFg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-freebsd-x64": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.17.1.tgz",
+			"integrity": "sha512-UD1FRC8j8xZstFXYsXwQkNmmg7vUbee006IqxokwDUUA+xEgKZDpLhBEiVKM08Urb+bn7Q0gn6M1pyNR0ng5mg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.17.1.tgz",
+			"integrity": "sha512-wFWC1wyf2ROFWTxK5x0Enm++DSof3EBQ/ypyAesMDLiYxOOASDoMOZG1ylWUnlKaCt5W7eNOWOzABpdfFf/ssA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.17.1.tgz",
+			"integrity": "sha512-k/hUif0GEBk/csSqCfTPXb8AAVs1NNWCa/skBghvNbTtORcWfOVqJ3mM+2pE189+enRm4UnryLREu5ysI0kXEQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.17.1.tgz",
+			"integrity": "sha512-Cwm6A071ww60QouJ9LoHAwBgEoZzHQ0Qaqk2E7WLfBdiQN9mLXIDhnrpn04hlRElRPhLiu/dtg+o5PPLvaINXQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.17.1.tgz",
+			"integrity": "sha512-+hwlE2v3m0r3sk93SchJL1uyaKcPjf+NGO/TD2DZUDo+chXx7FfaEj0nUMewigSt7oZ2sQN9Z4NJOtUa75HE5Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.17.1.tgz",
+			"integrity": "sha512-bO+rsaE5Ox8cFyeL5Ct5tzot1TnQpFa/Wmu5k+hqBYSH2dNVDGoi0NizBN5QV8kOIC6O5MZr81UG4yW/2FyDTA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.17.1.tgz",
+			"integrity": "sha512-B/P+hxKQ1oX4YstI9Lyh4PGzqB87Ddqj/A4iyRBbPdXTcxa+WW3oRLx1CsJKLmHPdDk461Hmbghq1Bm3pl+8Aw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.17.1.tgz",
+			"integrity": "sha512-ulp2H3bFXzd/th2maH+QNKj5qgOhJ3v9Yspdf1svTw3CDOuuTl6sRKsWQ7MUw0vnkSNvQndtflBwVXgzZvURsQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.17.1.tgz",
+			"integrity": "sha512-LAXYVe3rKk09Zo9YKF2ZLBcH8sz8Oj+JIyiUxiHtq0hiYLMsN6dOpCf2hzQEjPAmsSEA/hdC1PVKeXo+oma8mQ==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.17.1.tgz",
+			"integrity": "sha512-3RAhxipMKE8RCSPn7O//sj440i+cYTgYbapLeOoDvQEt6R1QcJjTsFgI4iz99FhVj3YbPxlZmcLB5VW+ipyRTA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-linux-x64-musl": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.17.1.tgz",
+			"integrity": "sha512-wpjMEubGU8r9VjZTLdZR3aPHaBqTl8Jl8F4DBbgNoZ+yhkhQD1/MGvY70v2TLnAI6kAHSvcqgfvaqKDa2iWsPQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-openharmony-arm64": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.17.1.tgz",
+			"integrity": "sha512-XIE4w17RYAVIgx+9Gs3deTREq5tsmalbatYOOBGNdH7n0DfTE600c7wYXsp7ANc3BPDXsInnOzXDEPCvO1F6cg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-wasm32-wasi": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.17.1.tgz",
+			"integrity": "sha512-Lqi5BlHX3zS4bpSOkIbOKVf7DIk6Gvmdifr2OuOI58eUUyP944M8/OyaB09cNpPy9Vukj7nmmhOzj8pwLgAkIg==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@napi-rs/wasm-runtime": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.17.1.tgz",
+			"integrity": "sha512-l6lTcLBQVj1HNquFpXSsrkCIM8X5Hlng5YNQJrg00z/KyovvDV5l3OFhoRyZ+aLBQ74zUnMRaJZC7xcBnHyeNg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-win32-ia32-msvc": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-11.17.1.tgz",
+			"integrity": "sha512-VTzVtfnCCsU/6GgvursWoyZrhe3Gj/RyXzDWmh4/U1Y3IW0u1FZbp+hCIlBL16pRPbDc5YvXVtCOnA41QOrOoQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.17.1.tgz",
+			"integrity": "sha512-jRPVU+6/12baj87q2+UGRh30FBVBzqKdJ7rP/mSqiL1kpNQB9yZ1j0+m3sru1m+C8hiFK7lBFwjUtYUBI7+UpQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
 		"node_modules/@paralleldrive/cuid2": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -1589,6 +1923,17 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1625,24 +1970,21 @@
 			"integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
 			"license": "MIT"
 		},
-		"node_modules/@types/minimatch": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+		"node_modules/@types/node": {
+			"version": "25.2.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.2.tgz",
+			"integrity": "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~7.16.0"
+			}
 		},
 		"node_modules/@types/normalize-package-data": {
 			"version": "2.4.4",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
 			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@types/parse-json": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-			"integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1836,67 +2178,6 @@
 			"engines": {
 				"node": ">=18"
 			}
-		},
-		"node_modules/@vue/compiler-core": {
-			"version": "3.5.27",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.27.tgz",
-			"integrity": "sha512-gnSBQjZA+//qDZen+6a2EdHqJ68Z7uybrMf3SPjEGgG4dicklwDVmMC1AeIHxtLVPT7sn6sH1KOO+tS6gwOUeQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.28.5",
-				"@vue/shared": "3.5.27",
-				"entities": "^7.0.0",
-				"estree-walker": "^2.0.2",
-				"source-map-js": "^1.2.1"
-			}
-		},
-		"node_modules/@vue/compiler-dom": {
-			"version": "3.5.27",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.27.tgz",
-			"integrity": "sha512-oAFea8dZgCtVVVTEC7fv3T5CbZW9BxpFzGGxC79xakTr6ooeEqmRuvQydIiDAkglZEAd09LgVf1RoDnL54fu5w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vue/compiler-core": "3.5.27",
-				"@vue/shared": "3.5.27"
-			}
-		},
-		"node_modules/@vue/compiler-sfc": {
-			"version": "3.5.27",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.27.tgz",
-			"integrity": "sha512-sHZu9QyDPeDmN/MRoshhggVOWE5WlGFStKFwu8G52swATgSny27hJRWteKDSUUzUH+wp+bmeNbhJnEAel/auUQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.28.5",
-				"@vue/compiler-core": "3.5.27",
-				"@vue/compiler-dom": "3.5.27",
-				"@vue/compiler-ssr": "3.5.27",
-				"@vue/shared": "3.5.27",
-				"estree-walker": "^2.0.2",
-				"magic-string": "^0.30.21",
-				"postcss": "^8.5.6",
-				"source-map-js": "^1.2.1"
-			}
-		},
-		"node_modules/@vue/compiler-ssr": {
-			"version": "3.5.27",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.27.tgz",
-			"integrity": "sha512-Sj7h+JHt512fV1cTxKlYhg7qxBvack+BGncSpH+8vnN+KN95iPIcqB5rsbblX40XorP+ilO7VIKlkuu3Xq2vjw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vue/compiler-dom": "3.5.27",
-				"@vue/shared": "3.5.27"
-			}
-		},
-		"node_modules/@vue/shared": {
-			"version": "3.5.27",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.27.tgz",
-			"integrity": "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/abbrev": {
 			"version": "3.0.1",
@@ -2139,16 +2420,6 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
-		"node_modules/array-differ": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
-			"integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -2164,16 +2435,6 @@
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
 			"license": "MIT"
-		},
-		"node_modules/array-union": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
 		},
 		"node_modules/arrgv": {
 			"version": "1.0.2",
@@ -2618,15 +2879,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/callsite": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-			"integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
-			"dev": true,
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/callsites": {
@@ -3450,23 +3702,6 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/cosmiconfig": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/parse-json": "^4.0.0",
-				"import-fresh": "^3.2.1",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.10.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/cross-env": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
@@ -3706,214 +3941,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/depcheck": {
-			"version": "1.4.7",
-			"resolved": "https://registry.npmjs.org/depcheck/-/depcheck-1.4.7.tgz",
-			"integrity": "sha512-1lklS/bV5chOxwNKA/2XUUk/hPORp8zihZsXflr8x0kLwmcZ9Y9BsS6Hs3ssvA+2wUVbG0U2Ciqvm1SokNjPkA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.23.0",
-				"@babel/traverse": "^7.23.2",
-				"@vue/compiler-sfc": "^3.3.4",
-				"callsite": "^1.0.0",
-				"camelcase": "^6.3.0",
-				"cosmiconfig": "^7.1.0",
-				"debug": "^4.3.4",
-				"deps-regex": "^0.2.0",
-				"findup-sync": "^5.0.0",
-				"ignore": "^5.2.4",
-				"is-core-module": "^2.12.0",
-				"js-yaml": "^3.14.1",
-				"json5": "^2.2.3",
-				"lodash": "^4.17.21",
-				"minimatch": "^7.4.6",
-				"multimatch": "^5.0.0",
-				"please-upgrade-node": "^3.2.0",
-				"readdirp": "^3.6.0",
-				"require-package-name": "^2.0.1",
-				"resolve": "^1.22.3",
-				"resolve-from": "^5.0.0",
-				"semver": "^7.5.4",
-				"yargs": "^16.2.0"
-			},
-			"bin": {
-				"depcheck": "bin/depcheck.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/depcheck/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/depcheck/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/depcheck/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/depcheck/node_modules/camelcase": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/depcheck/node_modules/cliui": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
-				"wrap-ansi": "^7.0.0"
-			}
-		},
-		"node_modules/depcheck/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/depcheck/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/depcheck/node_modules/minimatch": {
-			"version": "7.4.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-			"integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/depcheck/node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/depcheck/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/depcheck/node_modules/wrap-ansi": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/depcheck/node_modules/yargs": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^7.0.2",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.0",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^20.2.2"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/depcheck/node_modules/yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/depd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3923,13 +3950,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/deps-regex": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.2.0.tgz",
-			"integrity": "sha512-PwuBojGMQAYbWkMXOY9Pd/NWCDNHVH12pnS7WHqZkTSeMESe4hwnKKRp0yR87g37113x4JPbo/oIvXY+s/f56Q==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/destroy": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -3938,16 +3958,6 @@
 			"engines": {
 				"node": ">= 0.8",
 				"npm": "1.2.8000 || >= 1.4.16"
-			}
-		},
-		"node_modules/detect-file": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-			"integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/detect-libc": {
@@ -4225,19 +4235,6 @@
 				"node": ">=4.0.0"
 			}
 		},
-		"node_modules/entities": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
 		"node_modules/env-paths": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -4254,16 +4251,6 @@
 			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/error-ex": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-			"integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-arrayish": "^0.2.1"
-			}
 		},
 		"node_modules/es-define-property": {
 			"version": "1.0.1",
@@ -4929,19 +4916,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/expand-tilde": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-			"integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"homedir-polyfill": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/exponential-backoff": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
@@ -5143,6 +5117,26 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"node_modules/fd-package-json": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+			"integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"walk-up-path": "^4.0.0"
+			}
+		},
+		"node_modules/fd-package-json/node_modules/walk-up-path": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+			"integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
 		"node_modules/fdir": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5317,22 +5311,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/findup-sync": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
-			"integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"detect-file": "^1.0.0",
-				"is-glob": "^4.0.3",
-				"micromatch": "^4.0.4",
-				"resolve-dir": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			}
-		},
 		"node_modules/flat-cache": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -5385,6 +5363,22 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/formatly": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
+			"integrity": "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fd-package-json": "^2.0.0"
+			},
+			"bin": {
+				"formatly": "bin/index.mjs"
+			},
+			"engines": {
+				"node": ">=18.3.0"
 			}
 		},
 		"node_modules/formidable": {
@@ -5650,65 +5644,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/global-modules": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"global-prefix": "^1.0.1",
-				"is-windows": "^1.0.1",
-				"resolve-dir": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/global-prefix": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-			"integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"expand-tilde": "^2.0.2",
-				"homedir-polyfill": "^1.0.1",
-				"ini": "^1.3.4",
-				"is-windows": "^1.0.1",
-				"which": "^1.2.14"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/global-prefix/node_modules/ini": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/global-prefix/node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/global-prefix/node_modules/which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"which": "bin/which"
-			}
-		},
 		"node_modules/globals": {
 			"version": "16.5.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
@@ -5852,19 +5787,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/homedir-polyfill": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
-			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"parse-passwd": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/hosted-git-info": {
@@ -6273,13 +6195,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/is-arrayish": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
@@ -6698,6 +6613,16 @@
 				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
+		"node_modules/jiti": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
 		"node_modules/js-string-escape": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -6872,6 +6797,81 @@
 				"graceful-fs": "^4.1.9"
 			}
 		},
+		"node_modules/knip": {
+			"version": "5.83.1",
+			"resolved": "https://registry.npmjs.org/knip/-/knip-5.83.1.tgz",
+			"integrity": "sha512-av3ZG/Nui6S/BNL8Tmj12yGxYfTnwWnslouW97m40him7o8MwiMjZBY9TPvlEWUci45aVId0/HbgTwSKIDGpMw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/webpro"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/knip"
+				}
+			],
+			"license": "ISC",
+			"dependencies": {
+				"@nodelib/fs.walk": "^1.2.3",
+				"fast-glob": "^3.3.3",
+				"formatly": "^0.3.0",
+				"jiti": "^2.6.0",
+				"js-yaml": "^4.1.1",
+				"minimist": "^1.2.8",
+				"oxc-resolver": "^11.15.0",
+				"picocolors": "^1.1.1",
+				"picomatch": "^4.0.1",
+				"smol-toml": "^1.5.2",
+				"strip-json-comments": "5.0.3",
+				"zod": "^4.1.11"
+			},
+			"bin": {
+				"knip": "bin/knip.js",
+				"knip-bun": "bin/knip-bun.js"
+			},
+			"engines": {
+				"node": ">=18.18.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18",
+				"typescript": ">=5.0.4 <7"
+			}
+		},
+		"node_modules/knip/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
+			"license": "Python-2.0"
+		},
+		"node_modules/knip/node_modules/js-yaml": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/knip/node_modules/strip-json-comments": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+			"integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/less-openui5": {
 			"version": "0.11.6",
 			"resolved": "https://registry.npmjs.org/less-openui5/-/less-openui5-0.11.6.tgz",
@@ -6900,13 +6900,6 @@
 			"engines": {
 				"node": ">= 0.8.0"
 			}
-		},
-		"node_modules/lines-and-columns": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/linkify-it": {
 			"version": "5.0.0",
@@ -7008,16 +7001,6 @@
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^3.0.2"
-			}
-		},
-		"node_modules/magic-string": {
-			"version": "0.30.21",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
 		"node_modules/make-dir": {
@@ -7522,68 +7505,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
-		},
-		"node_modules/multimatch": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
-			"integrity": "sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/minimatch": "^3.0.3",
-				"array-differ": "^3.0.0",
-				"array-union": "^2.1.0",
-				"arrify": "^2.0.1",
-				"minimatch": "^3.0.4"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/multimatch/node_modules/arrify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/multimatch/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"bin": {
-				"nanoid": "bin/nanoid.cjs"
-			},
-			"engines": {
-				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-			}
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
@@ -8348,6 +8269,38 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/oxc-resolver": {
+			"version": "11.17.1",
+			"resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.17.1.tgz",
+			"integrity": "sha512-pyRXK9kH81zKlirHufkFhOFBZRks8iAMLwPH8gU7lvKFiuzUH9L8MxDEllazwOb8fjXMcWjY1PMDfMJ2/yh5cw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			},
+			"optionalDependencies": {
+				"@oxc-resolver/binding-android-arm-eabi": "11.17.1",
+				"@oxc-resolver/binding-android-arm64": "11.17.1",
+				"@oxc-resolver/binding-darwin-arm64": "11.17.1",
+				"@oxc-resolver/binding-darwin-x64": "11.17.1",
+				"@oxc-resolver/binding-freebsd-x64": "11.17.1",
+				"@oxc-resolver/binding-linux-arm-gnueabihf": "11.17.1",
+				"@oxc-resolver/binding-linux-arm-musleabihf": "11.17.1",
+				"@oxc-resolver/binding-linux-arm64-gnu": "11.17.1",
+				"@oxc-resolver/binding-linux-arm64-musl": "11.17.1",
+				"@oxc-resolver/binding-linux-ppc64-gnu": "11.17.1",
+				"@oxc-resolver/binding-linux-riscv64-gnu": "11.17.1",
+				"@oxc-resolver/binding-linux-riscv64-musl": "11.17.1",
+				"@oxc-resolver/binding-linux-s390x-gnu": "11.17.1",
+				"@oxc-resolver/binding-linux-x64-gnu": "11.17.1",
+				"@oxc-resolver/binding-linux-x64-musl": "11.17.1",
+				"@oxc-resolver/binding-openharmony-arm64": "11.17.1",
+				"@oxc-resolver/binding-wasm32-wasi": "11.17.1",
+				"@oxc-resolver/binding-win32-arm64-msvc": "11.17.1",
+				"@oxc-resolver/binding-win32-ia32-msvc": "11.17.1",
+				"@oxc-resolver/binding-win32-x64-msvc": "11.17.1"
+			}
+		},
 		"node_modules/p-limit": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -8603,32 +8556,6 @@
 				"parse-statements": "1.0.11"
 			}
 		},
-		"node_modules/parse-json": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.0.0",
-				"error-ex": "^1.3.1",
-				"json-parse-even-better-errors": "^2.3.0",
-				"lines-and-columns": "^1.1.6"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/parse-json/node_modules/json-parse-even-better-errors": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/parse-ms": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
@@ -8640,16 +8567,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/parse-passwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/parse-statements": {
@@ -8781,16 +8698,6 @@
 			"integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
 			"license": "MIT"
 		},
-		"node_modules/path-type": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/peek-readable": {
 			"version": "5.4.2",
 			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.4.2.tgz",
@@ -8903,16 +8810,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/please-upgrade-node": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
-			"integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"semver-compare": "^1.0.0"
-			}
-		},
 		"node_modules/plur": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/plur/-/plur-5.1.0.tgz",
@@ -8941,35 +8838,6 @@
 			"engines": {
 				"node": ">=0.4",
 				"npm": ">=1.0.0"
-			}
-		},
-		"node_modules/postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/postcss/"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/funding/github/npm/postcss"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"nanoid": "^3.3.11",
-				"picocolors": "^1.1.1",
-				"source-map-js": "^1.2.1"
-			},
-			"engines": {
-				"node": "^10 || ^12 || >=14"
 			}
 		},
 		"node_modules/prelude-ls": {
@@ -9407,13 +9275,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/require-package-name": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
-			"integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/requizzle": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
@@ -9468,20 +9329,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/resolve-dir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-			"integrity": "sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"expand-tilde": "^2.0.0",
-				"global-modules": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/resolve-from": {
@@ -9691,13 +9538,6 @@
 			"bin": {
 				"semver": "bin/semver.js"
 			}
-		},
-		"node_modules/semver-compare": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-			"integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/send": {
 			"version": "0.19.2",
@@ -9976,6 +9816,19 @@
 				"npm": ">= 3.0.0"
 			}
 		},
+		"node_modules/smol-toml": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
+			"integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/cyyynthia"
+			}
+		},
 		"node_modules/socks": {
 			"version": "2.8.7",
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
@@ -10010,16 +9863,6 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/source-map-js": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -10925,6 +10768,14 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD",
+			"optional": true
+		},
 		"node_modules/tuf-js": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-3.1.0.tgz",
@@ -11013,6 +10864,21 @@
 				"is-typedarray": "^1.0.0"
 			}
 		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
 		"node_modules/uc.micro": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
@@ -11033,6 +10899,14 @@
 			"engines": {
 				"node": ">=18.17"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/unicorn-magic": {
 			"version": "0.3.0",
@@ -11538,16 +11412,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/yargs": {
 			"version": "17.7.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -11594,6 +11458,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"coverage": "rimraf test/tmp && nyc ava --node-arguments=\"--experimental-loader=@istanbuljs/esm-loader-hook\"",
 		"coverage-xunit": "nyc --reporter=text --reporter=text-summary --reporter=cobertura npm run unit-xunit",
 		"jsdoc": "npm run jsdoc-generate && open-cli jsdocs/index.html",
-		"jsdoc-generate": "jsdoc -c ./jsdoc.json -t $(node -p 'path.dirname(require.resolve(\"docdash\"))') ./lib/ || (echo 'Error during JSDoc generation! Check log.' && exit 1)",
+		"jsdoc-generate": "jsdoc -c ./jsdoc.json -t $(npm ls docdash --parseable | head -1) ./lib/ || (echo 'Error during JSDoc generation! Check log.' && exit 1)",
 		"jsdoc-watch": "npm run jsdoc && chokidar \"./lib/**/*.js\" -c \"npm run jsdoc-generate\"",
 		"preversion": "npm test",
 		"version": "git-chglog --sort semver --next-tag v$npm_package_version -o CHANGELOG.md v4.0.0.. && git add CHANGELOG.md",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"npm": ">= 8"
 	},
 	"scripts": {
-		"test": "npm run lint && npm run jsdoc-generate && npm run coverage && npm run depcheck",
+		"test": "npm run lint && npm run jsdoc-generate && npm run coverage && npm run knip",
 		"test-azure": "npm run coverage-xunit",
 		"lint": "eslint ./",
 		"unit": "rimraf test/tmp && ava",
@@ -46,7 +46,7 @@
 		"version": "git-chglog --sort semver --next-tag v$npm_package_version -o CHANGELOG.md v4.0.0.. && git add CHANGELOG.md",
 		"prepublishOnly": "git push --follow-tags",
 		"release-note": "git-chglog --sort semver -c .chglog/release-config.yml v$npm_package_version",
-		"depcheck": "depcheck --ignores @ui5/server,docdash,compression,cors,@istanbuljs/esm-loader-hook,cross-env --parsers='**/*.js:es6,**/*.cjs:es6'"
+		"knip": "knip --config knip.config.js"
 	},
 	"files": [
 		"CHANGELOG.md",
@@ -84,7 +84,8 @@
 			"coverage/**",
 			"test/**",
 			".eslintrc.cjs",
-			"jsdoc-plugin.cjs"
+			"jsdoc-plugin.cjs",
+			"knip.config.js"
 		],
 		"check-coverage": true,
 		"statements": 90,
@@ -144,7 +145,6 @@
 		"ava": "^6.4.1",
 		"chokidar-cli": "^3.0.0",
 		"cross-env": "^10.1.0",
-		"depcheck": "^1.4.7",
 		"docdash": "^2.0.2",
 		"eslint": "^9.39.2",
 		"eslint-config-google": "^0.14.0",
@@ -153,6 +153,7 @@
 		"esmock": "^2.7.3",
 		"globals": "^16.5.0",
 		"jsdoc": "^4.0.5",
+		"knip": "^5.83.1",
 		"nyc": "^17.1.0",
 		"open-cli": "^8.0.0",
 		"rimraf": "^6.1.2",


### PR DESCRIPTION
Due to the deprecation of depcheck we migrated to knip, which is in active development and has more features. As a first step we only activate the checking of unused dependencies.

The reason why we replaced the docdash jsdoc template path lookup in the jsdoc script is that knip fails to detect that a dependency (jsdoc) is used when a command inside of the package.json contains JavaScript code (via sub-shell).

JIRA: CPOUI5FOUNDATION-1126