### PR TITLE
[INTERNAL] Bump qs to 6.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5281,6 +5281,22 @@
 				"npm": "1.2.8000 || >= 1.4.16"
 			}
 		},
+		"node_modules/express/node_modules/body-parser/node_modules/qs": {
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+			"integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/express/node_modules/content-type": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -5325,22 +5341,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT"
-		},
-		"node_modules/express/node_modules/qs": {
-			"version": "6.15.3",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"es-define-property": "^1.0.1",
-				"side-channel": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/express/node_modules/raw-body": {
 			"version": "2.5.3",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,12 @@
 		"type": "git",
 		"url": "git@github.com:SAP/ui5-server.git"
 	},
+	"overrides": {
+		"qs": "^6.16.0",
+		"body-parser@1.20.6": {
+			"qs": "^6.16.0"
+		}
+	},
 	"dependencies": {
 		"@ui5/builder": "^4.3.1",
 		"@ui5/fs": "^4.0.6",


### PR DESCRIPTION
Bump qs to a non vulenrable version and enforce overrides for it.

Resolves GHSA-x5fp-wj9c-mxmx & GHSA-4mjr-xmp4-gh2g
